### PR TITLE
Release noteに主な依存OSSのバージョンを記載する

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +29,8 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - run: npm ci
-      - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
-      - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
-      - run: node ./scripts/electron-ver.js
+      # - run: npm ci
+      # - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
+      # - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
+      # - run: node ./scripts/electron-ver.js
+      - run: gh release view 0.6.1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   test:
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,20 +19,3 @@ jobs:
       - run: npm ci
       - run: npm run type-check
       - run: npm run lint
-
-  note:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: npm
-      - run: npm ci
-      - run: gh release view 0.6.1 --json body --jq '.body' > release-note.md
-      - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
-      - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
-      - run: node ./scripts/electron-ver.js >> release-note.md
-      - run: cat release-note.md
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,4 +30,5 @@ jobs:
           cache: npm
       - run: npm ci
       - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
-      - run: echo ${{ env.ELECTRON_VER }}
+      - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
+      - run: node ./scripts/electron-ver.js

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,8 +29,8 @@ jobs:
           node-version: 18
           cache: npm
       - run: npm ci
-      - run: ELECTRON_VER=$(npx electron -v)
+      - run: ELECTRON_VER=$(npx electron -v | grep v)
       - run: echo $ELECTRON_VER
-      - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS > DEPS
+      - run: curl -sL https://raw.githubusercontent.com/electron/electron/v28.0.0/DEPS > DEPS
       - run: cat DEPS
       - run: node ./scripts/electron-ver.js

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,5 +31,5 @@ jobs:
       - run: npm ci
       - run: ELECTRON_VER=$(npx electron -v)
       - run: echo $ELECTRON_VER
-      - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS
+      - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS > DEPS
       - run: node ./scripts/electron-ver.js

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,3 +19,16 @@ jobs:
       - run: npm ci
       - run: npm run type-check
       - run: npm run lint
+
+  note:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: ELECTRON_VER=$(npx electron -v)
+      - run: echo $ELECTRON_VER
+      - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS
+      - run: node ./scripts/electron-ver.js

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,8 +29,6 @@ jobs:
           node-version: 18
           cache: npm
       - run: npm ci
-      - run: ELECTRON_VER=$(npx electron -v | grep v)
+      - run: npx electron -v
+      - run: ELECTRON_VER=$(npx electron -v 2>&1 | grep v)
       - run: echo $ELECTRON_VER
-      - run: curl -sL https://raw.githubusercontent.com/electron/electron/v28.0.0/DEPS > DEPS
-      - run: cat DEPS
-      - run: node ./scripts/electron-ver.js

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: 18
           cache: npm
+      - run: npm ci
       - run: ELECTRON_VER=$(npx electron -v)
       - run: echo $ELECTRON_VER
       - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,10 +29,11 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      # - run: npm ci
-      # - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
-      # - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
-      # - run: node ./scripts/electron-ver.js
-      - run: gh release view 0.6.1
+      - run: npm ci
+      - run: gh release view 0.6.1 --json body --jq '.body' > release-note.md
+      - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
+      - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
+      - run: node ./scripts/electron-ver.js >> release-note.md
+      - run: cat release-note.md
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,5 @@ jobs:
           node-version: 18
           cache: npm
       - run: npm ci
-      - run: npx electron -v
-      - run: ELECTRON_VER=$(npx electron -v 2>&1 | grep v)
-      - run: echo $ELECTRON_VER
+      - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
+      - run: echo ${{ env.ELECTRON_VER }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,4 +32,5 @@ jobs:
       - run: ELECTRON_VER=$(npx electron -v)
       - run: echo $ELECTRON_VER
       - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS > DEPS
+      - run: cat DEPS
       - run: node ./scripts/electron-ver.js

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,3 +34,5 @@ jobs:
       # - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
       # - run: node ./scripts/electron-ver.js
       - run: gh release view 0.6.1
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,10 +18,11 @@ jobs:
           node-version: 18
           cache: npm
       - run: npm ci
+      - run: gh release view 0.6.1 --json body --jq '.body' > release-note.md
       - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
       - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
-      - run: node ./scripts/electron-ver.js
-      - run: gh release update ${{ env.TAG_ID }} --notes-file ./scripts/release-notes.md
+      - run: node ./scripts/electron-ver.js >> release-note.md
+      - run: gh release edit ${{ env.TAG_ID }} --notes-file release-notes.md
 
   linux:
     if: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,9 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - run: curl -sL https://raw.githubusercontent.com/electron/electron/v28.0.0/DEPS > DEPS
+      - run: npm ci
+      - run: echo "ELECTRON_VER=$(npx electron -v)" >> $GITHUB_ENV
+      - run: curl -s https://raw.githubusercontent.com/electron/electron/${{ env.ELECTRON_VER }}/DEPS > DEPS
       - run: node ./scripts/electron-ver.js
       - run: gh release update ${{ env.TAG_ID }} --notes-file ./scripts/release-notes.md
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS > DEPS
+      - run: curl -sL https://raw.githubusercontent.com/electron/electron/v28.0.0/DEPS > DEPS
       - run: node ./scripts/electron-ver.js
       - run: gh release update ${{ env.TAG_ID }} --notes-file ./scripts/release-notes.md
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,18 @@ env:
   TAG_ID: ${{ github.event.release.tag_name }}
 
 jobs:
+  note:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: curl -sL https://github.com/electron/electron/blob/v28.0.0/DEPS > DEPS
+      - run: node ./scripts/electron-ver.js
+      - run: gh release update ${{ env.TAG_ID }} --notes-file ./scripts/release-notes.md
+
   linux:
     if: false
     runs-on: ubuntu-latest

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -31,6 +31,7 @@ export const main = async () => {
 	mainWindow.setBrowserView(webview);
 	windowUtils.putWebview(mainWindow, webview);
 
+	ipcMain.handle('app:version', () => `v${app.getVersion()}`);
 	ipcMain.on('app:ready', (_event) => {
 		log.verbose('App renderer is ready');
 

--- a/electron-src/preload/about.ts
+++ b/electron-src/preload/about.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('about', {
+	version: () => ipcRenderer.invoke('app:version'),
 	close: () => ipcRenderer.send('about:close'),
 	open: (url: string) => ipcRenderer.send('browser:open', url),
 });

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -110,7 +110,10 @@ const accessGithub = async ({
 };
 
 const getBaseUrl = () => {
-	const baseUrl = store.get('githubSetting')?.baseUrl;
+	const baseUrl = store.get('githubSetting', {
+		baseUrl: '',
+		token: '',
+	}).baseUrl;
 	if (!baseUrl) {
 		throw new Error('No GitHub baseURL set. Please set one in the settings.');
 	}
@@ -119,7 +122,7 @@ const getBaseUrl = () => {
 };
 
 const getToken = () => {
-	const token = store.get('githubSetting')?.token;
+	const token = store.get('githubSetting', { baseUrl: '', token: '' }).token;
 	if (!token) {
 		throw new Error('No GitHub token set. Please set one in the settings.');
 	}

--- a/electron-src/utils/window.ts
+++ b/electron-src/utils/window.ts
@@ -76,7 +76,7 @@ const boundPosition = { x: 600, y: 24 } as const;
 export const putWebview = (
 	mainWindow: BrowserWindow,
 	webview: BrowserView,
-	{ noHeaderFlag }: { noHeaderFlag?: boolean } = {},
+	{ noHeaderFlag }: WebviewPutOptions = {},
 ) => {
 	const bounds = mainWindow.getBounds();
 	const option = { isNoHeader: noHeaderFlag === true, isMac };
@@ -107,4 +107,8 @@ const calcWebviewHeight = (
 		return height;
 	}
 	return height - (option.isMac ? 27 : 59);
+};
+
+export type WebviewPutOptions = {
+	noHeaderFlag?: boolean;
 };

--- a/electron-src/utils/window.ts
+++ b/electron-src/utils/window.ts
@@ -49,7 +49,7 @@ export const createAbout = (parentWindow: BrowserWindow) => {
 		parent: parentWindow,
 		modal: true,
 		width: 500,
-		height: 670 + (isMac ? 0 : 27),
+		height: 270 + (isMac ? 0 : 27),
 		show: false,
 		resizable: false,
 		fullscreenable: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "関係しているGitHubのIssuesを表示・管理するデスクトップアプリ",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/interfaces/index.ts
+++ b/renderer/interfaces/index.ts
@@ -16,6 +16,7 @@ declare global {
 			cancel: () => void;
 		};
 		about: {
+			version: () => Promise<string>;
 			close: () => void;
 			open: (url: string) => void;
 		};

--- a/renderer/pages/about.tsx
+++ b/renderer/pages/about.tsx
@@ -1,20 +1,7 @@
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Head from 'next/head';
-import {
-	Box,
-	Button,
-	Grid,
-	Link,
-	Paper,
-	Table,
-	TableBody,
-	TableCell,
-	TableContainer,
-	TableHead,
-	TableRow,
-	Typography,
-} from '@mui/material';
+import { Box, Button, Grid, Link, Typography } from '@mui/material';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { Heading } from '../components/Heading';
@@ -31,7 +18,6 @@ const AboutPage = () => (
 
 		<AppInfo />
 		<ButtonArea />
-		<OssList />
 		<CopyRight />
 	</Box>
 );
@@ -94,46 +80,6 @@ const AppInfo = () => {
 			</Grid>
 		</Box>
 	);
-};
-
-const OssData: OssInfoProps[] = [
-	{ id: 'nodejs', name: 'Node.js', version: '18.18.2' },
-	{ id: 'electron', name: 'Electron', version: '28.0.0' },
-	{ id: 'react', name: 'React', version: '18.2.0' },
-	{ id: 'nextjs', name: 'Next.js', version: '14.0.4' },
-	{ id: 'chronium', name: 'Chronium', version: '120.0.6099.56' },
-	{ id: 'mui', name: 'Material UI', version: '5.15.0' },
-];
-const OssList = () => (
-	<Box component="section" my={3}>
-		<Heading level={2} hidden>
-			使用しているOSSの一覧
-		</Heading>
-
-		<TableContainer component={Paper}>
-			<Table>
-				<TableHead>
-					{OssInfo({ id: 'header', name: 'OSS', version: 'Version' })}
-				</TableHead>
-				<TableBody>
-					{OssData.map((data: OssInfoProps) => (
-						<OssInfo key={data.id} {...data} />
-					))}
-				</TableBody>
-			</Table>
-		</TableContainer>
-	</Box>
-);
-const OssInfo = ({ id: _id, name, version }: OssInfoProps) => (
-	<TableRow>
-		<TableCell>{name}</TableCell>
-		<TableCell>{version}</TableCell>
-	</TableRow>
-);
-type OssInfoProps = {
-	id: string;
-	name: string;
-	version: string;
 };
 
 const ButtonArea = () => {

--- a/renderer/pages/about.tsx
+++ b/renderer/pages/about.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Head from 'next/head';
 import {
@@ -36,9 +37,14 @@ const AboutPage = () => (
 );
 
 const AppInfo = () => {
+	const [version, setVersion] = useState('');
 	const handleOpenSource = (url: string) => {
 		window.about?.open(url);
 	};
+
+	useEffect(() => {
+		window.about?.version().then((v) => setVersion(v));
+	}, []);
 
 	return (
 		<Box component="section" my={3}>
@@ -63,7 +69,7 @@ const AppInfo = () => {
 							<Typography variant="h3">Amethyst</Typography>
 						</Grid>
 						<Grid item>
-							<Typography variant="subtitle1">v0.0.1</Typography>
+							<Typography variant="subtitle1">{version}</Typography>
 						</Grid>
 					</Grid>
 					<Grid item>

--- a/scripts/electron-ver.js
+++ b/scripts/electron-ver.js
@@ -2,12 +2,14 @@ const { execSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
+console.log('');
 const main = () => {
 	const result = {
 		...collectDependencyVersions(),
 		...collectElectronEnvVersions(),
 	};
 
+	console.log('## Electron Environment');
 	console.log('| OSS | Version |');
 	console.log('|:---|---:|');
 	console.log(`| Electron | ${result.electron} |`);

--- a/scripts/electron-ver.js
+++ b/scripts/electron-ver.js
@@ -1,0 +1,51 @@
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const main = () => {
+	const result = {
+		...collectDependencyVersions(),
+		...collectElectronEnvVersions(),
+	};
+
+	console.log('| OSS | Version |');
+	console.log('|:---|---:|');
+	console.log(`| Electron | ${result.electron} |`);
+	console.log(`| Chromium | ${result.chromium} |`);
+	console.log(`| Node.js | ${result.node} |`);
+	console.log(`| React | ${result.react} |`);
+	console.log(`| Next.js | ${result.next} |`);
+	console.log(`| Material UI | ${result.mui} |`);
+};
+
+const collectDependencyVersions = () => {
+	const result = JSON.parse(execSync('npm ls --json').toString());
+	return {
+		electron: result.dependencies.electron.version,
+		react: result.dependencies.react.version,
+		next: result.dependencies.next.version,
+		mui: result.dependencies['@mui/material'].version,
+	};
+};
+
+const collectElectronEnvVersions = () => {
+	const filepath = path.resolve(process.cwd(), 'DEPS');
+	const deps = fs.readFileSync(filepath).toString();
+	const lines = deps.split('\n');
+
+	return {
+		chromium: extraVerion('chromium', lines),
+		node: extraVerion('node', lines),
+	};
+};
+
+const extraVerion = (target, lines) => {
+	for (let i=0; i<lines.length; i++) {
+		if (lines[i].includes(`${target}_version`)) {
+			const result = /'v?(?<version>.+)'/g.exec(lines[i+1]);
+			return result.groups.version;
+		}
+	}
+};
+
+main();


### PR DESCRIPTION
# 概要

Release noteにElectronやNode.jsなどの主な依存OSSのバージョンを記載する

# 詳細

- Releast Noteに主な依存OSSのバージョンを記載
  - Electron
  - Chromium
  - Node.js
  - React
  - Next.js
  - Material UI
- Aboutページにリリースバージョンを表示する
- Aboutページから依存OSSのバージョン記載を削除する
