### PR TITLE
WindowsのビルドをMSIに変更

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run dist
-      - run: gh release upload ${{ env.TAG_ID }} "dist\amethyst-${{ env.TAG_ID }}-win.exe"
+      - run: gh release upload ${{ env.TAG_ID }} "dist\amethyst-${{ env.TAG_ID }}-win.msi"
 
   macos:
     runs-on: macos-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amethyst",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amethyst",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "関係しているGitHubのIssuesを表示・管理するデスクトップアプリ",
   "main": "main/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
       "icon": "docs/img/icon.icns"
     },
     "win": {
-      "target": "portable",
+      "target": "msi",
       "icon": "docs/img/icon.ico"
     }
   },


### PR DESCRIPTION
# 概要

Windowsでもインストーラ経由でインストールするためにビルドをMSIに変更する

# 詳細

- WindowsのビルドターゲットをMSIに変更
