### PR TITLE
起動時や設定時にGitHubへのアクセスでエラーが発生した場合はアラートを表示

### DIFF
--- a/electron-src/enum/StoreDataFlag.ts
+++ b/electron-src/enum/StoreDataFlag.ts
@@ -1,0 +1,28 @@
+import { safeUnreachable } from '../utils/typescript';
+
+const VALID = Symbol('正当なデータ');
+const INVALID = Symbol('不当なデータ');
+type StoreDataFlagType = typeof VALID | typeof INVALID;
+class StoreDataFlag {
+	private flag: StoreDataFlagType;
+
+	constructor(flag: StoreDataFlagType) {
+		this.flag = flag;
+	}
+
+	public isInvalid(): boolean {
+		switch (this.flag) {
+			case VALID:
+				return false;
+			case INVALID:
+				return true;
+		}
+
+		safeUnreachable(this.flag);
+	}
+}
+
+export default {
+	VALID: new StoreDataFlag(VALID),
+	INVALID: new StoreDataFlag(INVALID),
+} as const;

--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -1,0 +1,66 @@
+import { app, dialog, ipcMain, Notification } from 'electron';
+import log from 'electron-log/main';
+import dayjs from 'dayjs';
+import { gainUserInfo, gainIssues, githubAppSettings } from './utils/github';
+import { store } from './utils/store';
+
+let latestIssueGainTime: dayjs.Dayjs | null = null;
+
+export const gainGithubAllData = async (isBoot: boolean) => {
+	log.debug('main.gainGithubAllData を実行します');
+	try {
+		await Promise.all([gainGithubUser(), gainGithubIssues()]);
+	} catch (error) {
+		log.error(
+			new Error('GitHub APIからのデータ取得に失敗しました', { cause: error }),
+		);
+		if (isBoot) {
+			ipcMain.once('app:ready', () => {
+				showErrorDialog();
+			});
+		} else {
+			showErrorDialog();
+		}
+	}
+};
+
+export const gainGithubUser = async () => {
+	log.debug('main.gainGithubUser を実行します');
+	const userInfo = await gainUserInfo();
+
+	store.set('userInfo', userInfo);
+	return userInfo;
+};
+export const gainGithubIssues = async () => {
+	log.debug('main.gainGithubIssues を実行します');
+	const now = dayjs();
+	const issues = await gainIssues(
+		now.subtract(githubAppSettings.terms.value, githubAppSettings.terms.unit),
+	);
+
+	if (
+		latestIssueGainTime &&
+		issues.some((issue) => dayjs(issue.updatedAt).isAfter(latestIssueGainTime))
+	) {
+		const notification = new Notification({
+			title: 'Issueが更新されました',
+			body: '更新されたIssue・PRがあります。Issue・PRを確認してください。',
+		});
+		notification.show();
+	}
+	latestIssueGainTime = now;
+
+	store.set('issueData', { updatedAt: now.toISOString(), issues });
+	return issues;
+};
+
+const showErrorDialog = () => {
+	dialog.showErrorBox(
+		'GitHub APIからのデータ取得に失敗しました',
+		'tokenの有効期限が切れている可能性があります。設定画面からtokenを再設定してください。',
+	);
+	app.applicationMenu?.items
+		.find((item) => item.label === 'Amethyst')
+		?.submenu?.items.find((item) => item.label === 'Preferences')
+		?.click();
+};

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -3,6 +3,7 @@ import {
 	app,
 	BrowserView,
 	BrowserWindow,
+	dialog,
 	ipcMain,
 	Menu,
 	Notification,
@@ -39,7 +40,15 @@ export const main = async () => {
 	mainWindow.loadURL(getLoadedUrl());
 	if (!storeDataFlag.isInvalid()) {
 		await Promise.all([gainGithubUser(), gainGithubIssues()]).catch((err) => {
-			log.error(err);
+			log.error(
+				new Error('GitHub APIからのデータ取得に失敗しました', { cause: err }),
+			);
+			mainWindow.once('ready-to-show', () => {
+				dialog.showErrorBox(
+					'GitHub APIからのデータ取得に失敗しました',
+					'tokenの有効期限が切れている可能性があります。設定画面からtokenを再設定してください。',
+				);
+			});
 		});
 	}
 

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -29,7 +29,6 @@ import { getLoadedUrl } from './utils/render';
 import { store } from './utils/store';
 import * as windowUtils from './utils/window';
 
-const isMac = process.platform === 'darwin';
 let latestIssueGainTime: dayjs.Dayjs | null = null;
 
 export const main = async () => {
@@ -43,11 +42,15 @@ export const main = async () => {
 			log.error(
 				new Error('GitHub APIからのデータ取得に失敗しました', { cause: err }),
 			);
-			mainWindow.once('ready-to-show', () => {
+			ipcMain.once('app:ready', () => {
 				dialog.showErrorBox(
 					'GitHub APIからのデータ取得に失敗しました',
 					'tokenの有効期限が切れている可能性があります。設定画面からtokenを再設定してください。',
 				);
+				app.applicationMenu?.items
+					.find((item) => item.label === 'Amethyst')
+					?.submenu?.items.find((item) => item.label === 'Preferences')
+					?.click();
 			});
 		});
 	}
@@ -156,11 +159,7 @@ const setupModalWindow = (
 		settingWindow,
 		aboutWindow,
 	});
-	if (isMac) {
-		Menu.setApplicationMenu(menu);
-	} else {
-		mainWindow.setMenu(menu);
-	}
+	Menu.setApplicationMenu(menu);
 	mainWindow.show();
 
 	if (settingShowFlag) {

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -33,14 +33,18 @@ let latestIssueGainTime: dayjs.Dayjs | null = null;
 
 export const main = async () => {
 	const mainWindow = setupMainWindow();
+	const storeDataFlag = checkStoreData();
 
 	await prepareNext('./renderer');
 	mainWindow.loadURL(getLoadedUrl());
-	gainGithubUser().catch((_err) => {});
-	gainGithubIssues().catch((_err) => {});
+	if (!storeDataFlag.isInvalid()) {
+		await Promise.all([gainGithubUser(), gainGithubIssues()]).catch((err) => {
+			log.error(err);
+		});
+	}
 
 	const webview = setupWebview(mainWindow);
-	setupModalWindow(mainWindow, webview);
+	setupModalWindow(mainWindow, webview, storeDataFlag.isInvalid());
 	setupResizedSetting(mainWindow, webview);
 
 	setInterval(
@@ -130,7 +134,11 @@ const setupWebview = (mainWindow: BrowserWindow) => {
 	});
 	return webview;
 };
-const setupModalWindow = (mainWindow: BrowserWindow, webview: BrowserView) => {
+const setupModalWindow = (
+	mainWindow: BrowserWindow,
+	webview: BrowserView,
+	settingShowFlag: boolean,
+) => {
 	const settingWindow = windowUtils.createSetting(mainWindow);
 	const aboutWindow = windowUtils.createAbout(mainWindow);
 	const menu = createMenu({
@@ -146,7 +154,7 @@ const setupModalWindow = (mainWindow: BrowserWindow, webview: BrowserView) => {
 	}
 	mainWindow.show();
 
-	if (!checkStoreData()) {
+	if (settingShowFlag) {
 		settingWindow.show();
 	}
 };

--- a/electron-src/menu.ts
+++ b/electron-src/menu.ts
@@ -8,7 +8,7 @@ import {
 } from 'electron';
 import isDev from 'electron-is-dev';
 
-import { gainGithubUser, gainGithubIssues } from './main';
+import { gainGithubAllData } from './github';
 import { store } from './utils/store';
 import type { SettingData } from './preload/setting';
 
@@ -156,7 +156,7 @@ export const createMenu = ({
 				});
 				settingWindow.hide();
 
-				Promise.all([gainGithubUser(), gainGithubIssues()]);
+				gainGithubAllData(false);
 			},
 		)
 		.on('setting:cancel', (_event: Electron.IpcMainEvent) => {

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -6,6 +6,7 @@ import {
 	translateIssues,
 } from '../tanslators/GithubTranslator';
 import { store } from './store';
+import StoreDataFlag from '../enum/StoreDataFlag';
 import type { GithubUserInfo, GithubIssue } from '../types/GitHub';
 import type { UserInfo } from '../../types/User';
 import type { Issue } from '../../types/Issue';
@@ -55,7 +56,9 @@ export const gainIssues = async (target?: dayjs.Dayjs): Promise<Issue[]> => {
 
 export const checkStoreData = () => {
 	const githubSetting = store.get('githubSetting');
-	return githubAppSettings && githubSetting.baseUrl && githubSetting.token;
+	return githubSetting?.baseUrl && githubSetting?.token
+		? StoreDataFlag.VALID
+		: StoreDataFlag.INVALID;
 };
 
 const gainFilterdIssues = async (

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -106,3 +106,5 @@ export const store = new Store<{
 		},
 	},
 });
+
+store.clear();

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -106,5 +106,3 @@ export const store = new Store<{
 		},
 	},
 });
-
-store.clear();

--- a/electron-src/utils/typescript.ts
+++ b/electron-src/utils/typescript.ts
@@ -1,0 +1,3 @@
+export const safeUnreachable = (_x: never): never => {
+	throw new Error('Unreachable code');
+};

--- a/electron-src/utils/window.ts
+++ b/electron-src/utils/window.ts
@@ -30,6 +30,7 @@ export const createSetting = (parentWindow: BrowserWindow) => {
 		resizable: false,
 		closable: false,
 		fullscreenable: false,
+		autoHideMenuBar: true,
 		webPreferences: {
 			nodeIntegration: false,
 			contextIsolation: true,
@@ -52,6 +53,7 @@ export const createAbout = (parentWindow: BrowserWindow) => {
 		show: false,
 		resizable: false,
 		fullscreenable: false,
+		autoHideMenuBar: true,
 		webPreferences: {
 			nodeIntegration: false,
 			contextIsolation: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amethyst",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amethyst",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "関係しているGitHubのIssuesを表示・管理するデスクトップアプリ",
   "main": "main/index.js",
   "scripts": {


### PR DESCRIPTION
# 概要

起動時や設定時にGitHubへのアクセスでエラーが発生した場合は、アラートを表示して設定画面を表示する。

# 詳細

- 起動時にGitHubへのアクセスでエラーが発生した場合に、アラートと設定画面を表示する。
- 設定画面からURLやTokenを設定したときに、GitHubへのアクセスでエラーが発生した場合に、アラートと設定画面を表示する。

# 期待値

- [x] 異常なtokenの場合に、アラートと設定画面が表示される。
- [x] 正常なtokenの場合は、アラートも設定画面も表示されない。
