### PR TITLE
Material UIのThemeを操作できるようにする

### DIFF
--- a/renderer/components/Menu.tsx
+++ b/renderer/components/Menu.tsx
@@ -1,16 +1,21 @@
 import { useEffect, useContext, useState } from 'react';
 import dayjs from 'dayjs';
-import { UserInfoContext } from '../context/UserContext';
+import {
+	ColorModeContext,
+	ColorModeDispatchContext,
+} from '../context/ColorModeContext';
 import {
 	IssueFilterContext,
 	IssueFilterDispatchContext,
 	issueFilters,
 } from '../context/IssueFilterContext';
+import { UserInfoContext } from '../context/UserContext';
 import type { UserInfo } from '../../types/User';
 
 import {
 	Avatar,
 	Grid,
+	IconButton,
 	List,
 	ListItem,
 	ListItemButton,
@@ -19,6 +24,8 @@ import {
 	Typography,
 } from '@mui/material';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSun } from '@fortawesome/free-regular-svg-icons';
+import { faMoon } from '@fortawesome/free-solid-svg-icons';
 import { Heading } from './Heading';
 
 const Menu = () => {
@@ -94,6 +101,8 @@ const Filters = () => {
 
 const UpdatedAt = () => {
 	const [updatedAt, setUpdatedAt] = useState<string>('');
+	const colorMode = useContext(ColorModeContext);
+	const colorModeDispatch = useContext(ColorModeDispatchContext);
 	useEffect(() => {
 		window.electron.pushUpdatedAt((updatedAt) => {
 			if (!updatedAt) return '';
@@ -102,10 +111,31 @@ const UpdatedAt = () => {
 	}, []);
 
 	return (
-		<Grid item sx={{ width: '100%', px: 2, py: 1 }}>
-			<Typography sx={{ height: '1lh', overflow: 'hidden' }}>
-				{updatedAt}
-			</Typography>
+		<Grid
+			container
+			item
+			justifyContent="space-between"
+			alignItems="center"
+			sx={{ width: '100%', px: 2, py: 1 }}
+		>
+			<Grid item>
+				<Typography
+					sx={{ height: '1lh', overflow: 'hidden', verticalAlign: 'bottom' }}
+				>
+					{updatedAt}
+				</Typography>
+			</Grid>
+			<Grid item>
+				<IconButton
+					aria-label="toggle color mode"
+					size="small"
+					onClick={() => {
+						colorModeDispatch(colorMode === 'light' ? 'dark' : 'light');
+					}}
+				>
+					<FontAwesomeIcon icon={colorMode === 'light' ? faSun : faMoon} />
+				</IconButton>
+			</Grid>
 		</Grid>
 	);
 };

--- a/renderer/context/ColorModeContext.ts
+++ b/renderer/context/ColorModeContext.ts
@@ -1,0 +1,7 @@
+import { Dispatch, createContext } from 'react';
+import type { PaletteMode } from '@mui/material';
+
+export const ColorModeContext = createContext<PaletteMode>('light');
+export const ColorModeDispatchContext = createContext<Dispatch<PaletteMode>>(
+	(_v) => {},
+);

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -1,39 +1,65 @@
+import { Reducer, useMemo, useReducer } from 'react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import {
+	ColorModeContext,
+	ColorModeDispatchContext,
+} from '../context/ColorModeContext';
+import type { PaletteOptions } from '@mui/material/styles';
 
 import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
+import { PaletteMode } from '@mui/material';
 
-const theme = createTheme({
-	palette: {
-		primary: {
-			main: '#874692',
-			light: '#6c3a81',
-			dark: '#aa75b2',
-			contrastText: '#fff',
-		},
-		secondary: {
-			main: '#71b356',
-			light: '#4f813a',
-			dark: '#b5d8aa',
-			contrastText: '#000',
-		},
+const colorSet: PaletteOptions = {
+	primary: {
+		main: '#874692',
+		light: '#6c3a81',
+		dark: '#aa75b2',
+		contrastText: '#fff',
 	},
-});
+	secondary: {
+		main: '#71b356',
+		light: '#4f813a',
+		dark: '#b5d8aa',
+		contrastText: '#000',
+	},
+};
 
-const MyApp = ({ Component, pageProps }: AppProps) => (
-	<>
-		<Head>
-			<title>Amethyst</title>
-			<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-		</Head>
-		<ThemeProvider theme={theme}>
-			<Component {...pageProps} />
-		</ThemeProvider>
-	</>
-);
+const MyApp = ({ Component, pageProps }: AppProps) => {
+	const [mode, dispatch] = useReducer<Reducer<PaletteMode, PaletteMode>>(
+		(_prevMode, currentMode) => currentMode,
+		'light',
+	);
+	const theme = useMemo(
+		() =>
+			createTheme({
+				palette: {
+					...colorSet,
+					mode,
+				},
+			}),
+		[mode],
+	);
+
+	return (
+		<>
+			<Head>
+				<title>Amethyst</title>
+				<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+			</Head>
+			<ColorModeContext.Provider value={mode}>
+				<ColorModeDispatchContext.Provider value={dispatch}>
+					<ThemeProvider theme={theme}>
+						<Component {...pageProps} />
+					</ThemeProvider>
+				</ColorModeDispatchContext.Provider>
+			</ColorModeContext.Provider>
+		</>
+	);
+};
 
 export default MyApp;

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -1,10 +1,28 @@
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
+
+const theme = createTheme({
+	palette: {
+		primary: {
+			main: '#874692',
+			light: '#6c3a81',
+			dark: '#aa75b2',
+			contrastText: '#fff',
+		},
+		secondary: {
+			main: '#71b356',
+			light: '#4f813a',
+			dark: '#b5d8aa',
+			contrastText: '#000',
+		},
+	},
+});
 
 const MyApp = ({ Component, pageProps }: AppProps) => (
 	<>
@@ -12,7 +30,9 @@ const MyApp = ({ Component, pageProps }: AppProps) => (
 			<title>Amethyst</title>
 			<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 		</Head>
-		<Component {...pageProps} />
+		<ThemeProvider theme={theme}>
+			<Component {...pageProps} />
+		</ThemeProvider>
 	</>
 );
 


### PR DESCRIPTION
# 概要

Material UIのThemeを操作できるようにする。

# 詳細

- 全体に作用するように色を設定できるようにする
- ライトモードとダークモードを切り替え可能にする

# 期待値

- [x] メインカラーが紫
- [x] セカンダリカラーが緑
- [x] ライトモードとダークモードをワンクリックで切り替えられる
