### PR TITLE
レビュー状況を表示するようにする

### DIFF
--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -15,8 +15,8 @@ let latestIssueGainTime: dayjs.Dayjs = ((date: string) => {
 	return date
 		? dayjs(date)
 		: dayjs().subtract(
-				githubAppSettings.terms.value,
-				githubAppSettings.terms.unit,
+				githubAppSettings.targetTerm.value,
+				githubAppSettings.targetTerm.unit,
 			);
 })(store.get('issueData')?.updatedAt);
 

--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -49,7 +49,6 @@ export const gainGithubIssues = async () => {
 	log.debug('main.gainGithubIssues を実行します');
 	const now = dayjs();
 	const issues = await gainIssues(latestIssueGainTime);
-	log.verbose('gainGithubIssues:', issues);
 
 	latestIssueGainTime = now;
 	store.set('issueData', {

--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -9,8 +9,16 @@ import {
 	viewLatestRelease,
 } from './utils/github';
 import { store } from './utils/store';
+import { Issue } from '../types/Issue';
 
-let latestIssueGainTime: dayjs.Dayjs | null = null;
+let latestIssueGainTime: dayjs.Dayjs = ((date: string) => {
+	return date
+		? dayjs(date)
+		: dayjs().subtract(
+				githubAppSettings.terms.value,
+				githubAppSettings.terms.unit,
+			);
+})(store.get('issueData')?.updatedAt);
 
 export const gainGithubAllData = async (isBoot: boolean) => {
 	log.debug('main.gainGithubAllData を実行します');
@@ -40,9 +48,14 @@ export const gainGithubUser = async () => {
 export const gainGithubIssues = async () => {
 	log.debug('main.gainGithubIssues を実行します');
 	const now = dayjs();
-	const issues = await gainIssues(
-		now.subtract(githubAppSettings.terms.value, githubAppSettings.terms.unit),
-	);
+	const issues = await gainIssues(latestIssueGainTime);
+	log.verbose('gainGithubIssues:', issues);
+
+	latestIssueGainTime = now;
+	store.set('issueData', {
+		updatedAt: now.toISOString(),
+		issues: joinIssueData(issues),
+	});
 
 	if (
 		latestIssueGainTime &&
@@ -54,9 +67,7 @@ export const gainGithubIssues = async () => {
 		});
 		notification.show();
 	}
-	latestIssueGainTime = now;
 
-	store.set('issueData', { updatedAt: now.toISOString(), issues });
 	return issues;
 };
 
@@ -68,6 +79,14 @@ export const checkUpdate = async () => {
 		latestRelease: latestRelease.tag,
 	});
 	return semver.gt(latestRelease.tag, currentVersion);
+};
+
+const joinIssueData = (issues: Issue[]) => {
+	return issues.concat(
+		(store.get('issueData')?.issues ?? []).filter(
+			(issue) => !issues.some((i) => i.key === issue.key),
+		),
+	);
 };
 
 const showErrorDialog = () => {

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -24,6 +24,8 @@ import { getLoadedUrl } from './utils/render';
 import { store } from './utils/store';
 import * as windowUtils from './utils/window';
 
+const IssueGainInterval = 300000 as const; // 5分
+
 export const main = async () => {
 	const mainWindow = setupMainWindow();
 	const storeDataFlag = checkStoreData();
@@ -38,14 +40,9 @@ export const main = async () => {
 	setupModalWindow(mainWindow, webview, storeDataFlag.isInvalid());
 	setupResizedSetting(mainWindow, webview);
 
-	setInterval(
-		() => {
-			gainGithubIssues().then((issues) =>
-				mainWindow.webContents.send('app:pushIssues', issues),
-			);
-		},
-		5 * 60 * 1000,
-	);
+	setInterval(() => {
+		gainGithubIssues();
+	}, IssueGainInterval);
 
 	await announceUpdate(mainWindow);
 	await setupDevtools();
@@ -77,7 +74,7 @@ const setupMainWindow = () => {
 		store.onDidChange('issueData', (data) => {
 			log.debug('蓄積しているデータが更新されました');
 			if (!data) return;
-			mainWindow.webContents.send('app:pushUpdatedAt', data.updatedAt ?? {});
+			mainWindow.webContents.send('app:pushUpdatedAt', data.updatedAt);
 			mainWindow.webContents.send('app:pushIssues', data.issues ?? []);
 		});
 	});

--- a/electron-src/tanslators/GithubTranslator.ts
+++ b/electron-src/tanslators/GithubTranslator.ts
@@ -1,4 +1,4 @@
-import type { Issue, IssueLabel, IssueState } from '../../types/Issue';
+import type { Issue, IssueLabel, IssueState, Review } from '../../types/Issue';
 import type { UserInfo } from '../../types/User';
 import type { RecordValue } from '../../types/Utility';
 import type {
@@ -6,6 +6,7 @@ import type {
 	GithubIssue,
 	GithubLabel,
 	GithubFullIssueData,
+	GithubPrReview,
 } from '../types/GitHub';
 
 export const translateUserInfo = (userInfo: GithubUserInfo): UserInfo => ({
@@ -32,11 +33,7 @@ export const translateIssue = ({
 	creator: issue.user
 		? { login: issue.user.login, avatarUrl: issue.user.avatar_url }
 		: null,
-	reviewers: reviews.map((review) => ({
-		login: review.user.login,
-		avatarUrl: review.user.avatar_url,
-		state: review.state,
-	})),
+	reviews: translateIssueReviews(reviews),
 	updatedAt: issue.updated_at,
 });
 
@@ -85,3 +82,10 @@ const translateIssueLabel = (label: string | GithubLabel): IssueLabel => {
 		color: label.color,
 	};
 };
+
+const translateIssueReviews = (reviews: GithubPrReview[]): Review[] =>
+	reviews.map((review) => ({
+		login: review.user.login,
+		avatarUrl: review.user.avatar_url,
+		state: review.state,
+	}));

--- a/electron-src/tanslators/GithubTranslator.ts
+++ b/electron-src/tanslators/GithubTranslator.ts
@@ -33,7 +33,7 @@ export const translateIssue = ({
 	creator: issue.user
 		? { login: issue.user.login, avatarUrl: issue.user.avatar_url }
 		: null,
-	reviews: translateIssueReviews(reviews),
+	reviews: translateIssueReviews(reviews, issue.user?.node_id),
 	updatedAt: issue.updated_at,
 });
 
@@ -83,9 +83,13 @@ const translateIssueLabel = (label: string | GithubLabel): IssueLabel => {
 	};
 };
 
-const translateIssueReviews = (reviews: GithubPrReview[]): Review[] => {
+const translateIssueReviews = (
+	reviews: GithubPrReview[],
+	authorId: string = '',
+): Review[] => {
 	const users = reviews
 		.map((review) => review.user.node_id)
+		.filter((nodeId) => nodeId !== authorId)
 		.reduce<string[]>((acc, cur) => {
 			if (!acc.some((val) => val === cur)) {
 				acc.push(cur);

--- a/electron-src/tanslators/GithubTranslator.ts
+++ b/electron-src/tanslators/GithubTranslator.ts
@@ -21,7 +21,9 @@ export const translateIssue = (issue: GithubIssue): Issue => ({
 	state: translateIssueState(issue),
 	labels: translateIssueLabels(issue.labels),
 	reactions: issue.reactions ? issue.reactions.total_count : 0,
-	user: issue.user ? issue.user.login : null,
+	creator: issue.user
+		? { login: issue.user.login, avatarUrl: issue.user.avatar_url }
+		: null,
 	updatedAt: issue.updated_at,
 });
 

--- a/electron-src/tanslators/GithubTranslator.ts
+++ b/electron-src/tanslators/GithubTranslator.ts
@@ -83,9 +83,22 @@ const translateIssueLabel = (label: string | GithubLabel): IssueLabel => {
 	};
 };
 
-const translateIssueReviews = (reviews: GithubPrReview[]): Review[] =>
-	reviews.map((review) => ({
-		login: review.user.login,
-		avatarUrl: review.user.avatar_url,
-		state: review.state,
-	}));
+const translateIssueReviews = (reviews: GithubPrReview[]): Review[] => {
+	const users = reviews
+		.map((review) => review.user.node_id)
+		.reduce<string[]>((acc, cur) => {
+			if (!acc.some((val) => val === cur)) {
+				acc.push(cur);
+			}
+			return acc;
+		}, []);
+	reviews.reverse();
+
+	return users
+		.map((user) => reviews.find((review) => review.user.node_id === user)!)
+		.map((review) => ({
+			login: review.user.login,
+			avatarUrl: review.user.avatar_url,
+			state: review.state,
+		}));
+};

--- a/electron-src/tanslators/GithubTranslator.ts
+++ b/electron-src/tanslators/GithubTranslator.ts
@@ -24,6 +24,7 @@ export const translateIssue = (issue: GithubIssue): Issue => ({
 	creator: issue.user
 		? { login: issue.user.login, avatarUrl: issue.user.avatar_url }
 		: null,
+	reviewers: [],
 	updatedAt: issue.updated_at,
 });
 

--- a/electron-src/tanslators/GithubTranslator.ts
+++ b/electron-src/tanslators/GithubTranslator.ts
@@ -1,7 +1,12 @@
 import type { Issue, IssueLabel, IssueState } from '../../types/Issue';
 import type { UserInfo } from '../../types/User';
 import type { RecordValue } from '../../types/Utility';
-import type { GithubUserInfo, GithubIssue, GithubLabel } from '../types/GitHub';
+import type {
+	GithubUserInfo,
+	GithubIssue,
+	GithubLabel,
+	GithubFullIssueData,
+} from '../types/GitHub';
 
 export const translateUserInfo = (userInfo: GithubUserInfo): UserInfo => ({
 	login: userInfo.login,
@@ -9,9 +14,12 @@ export const translateUserInfo = (userInfo: GithubUserInfo): UserInfo => ({
 	name: userInfo.name,
 });
 
-export const translateIssues = (issues: GithubIssue[]): Issue[] =>
-	issues.map(translateIssue);
-export const translateIssue = (issue: GithubIssue): Issue => ({
+export const translateIssues = (data: GithubFullIssueData[]): Issue[] =>
+	data.map(translateIssue);
+export const translateIssue = ({
+	issue,
+	reviews,
+}: GithubFullIssueData): Issue => ({
 	id: issue.id,
 	key: issue.node_id,
 	number: issue.number,
@@ -24,7 +32,11 @@ export const translateIssue = (issue: GithubIssue): Issue => ({
 	creator: issue.user
 		? { login: issue.user.login, avatarUrl: issue.user.avatar_url }
 		: null,
-	reviewers: [],
+	reviewers: reviews.map((review) => ({
+		login: review.user.login,
+		avatarUrl: review.user.avatar_url,
+		state: review.state,
+	})),
 	updatedAt: issue.updated_at,
 });
 

--- a/electron-src/types/GitHub.d.ts
+++ b/electron-src/types/GitHub.d.ts
@@ -82,3 +82,15 @@ export interface GithubRelease {
 	body: string;
 	created_at: string;
 }
+
+export interface GithubPrReview {
+	id: number;
+	node_id: string;
+	user: GithubUserMinimumInfo;
+	state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED';
+}
+
+type GithubFullIssueData = {
+	issue: GithubIssue;
+	reviews: GithubPrReview[];
+};

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -47,14 +47,12 @@ export const gainIssues = async (target?: dayjs.Dayjs): Promise<Issue[]> => {
 		),
 	)
 		.then((values) => {
-			return values
-				.reduce((acc, cur) => acc.concat(cur), [])
-				.reduce((acc: GithubIssue[], cur: GithubIssue) => {
-					if (acc.every((issue) => issue.node_id !== cur.node_id)) {
-						acc.push(cur);
-					}
-					return acc;
-				}, []);
+			return values.flat().reduce((acc: GithubIssue[], cur: GithubIssue) => {
+				if (!acc.some((issue) => issue.node_id === cur.node_id)) {
+					acc.push(cur);
+				}
+				return acc;
+			}, []);
 		})
 		.then((issues) =>
 			issues.toSorted((a, b) =>

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -60,6 +60,16 @@ export const gainIssues = async (target?: dayjs.Dayjs): Promise<Issue[]> => {
 		.then(translateIssues);
 };
 
+export const gainPrReviews = async (repository: string, prNumber: number) => {
+	const results = await accessGithub({
+		path: `repos/${repository}/pulls/${prNumber}/reviews`,
+	});
+	if (!Array.isArray(results)) {
+		throw new Error('GitHub APIからのPRのレビューのresponseが異常値です');
+	}
+	return results;
+};
+
 export const checkStoreData = () => {
 	const githubSetting = store.get('githubSetting');
 	return githubSetting?.baseUrl && githubSetting?.token

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -18,11 +18,13 @@ import type { Issue } from '../../types/Issue';
 export const githubAppSettings: {
 	readonly filterTypes: readonly IssueFilterType[];
 	readonly perPage: number;
-	readonly terms: { value: number; unit: dayjs.ManipulateType };
+	readonly targetTerm: { value: number; unit: dayjs.ManipulateType };
+	readonly retentionTerm: { value: number; unit: dayjs.ManipulateType };
 } = {
 	filterTypes: ['assigned', 'created', 'mentioned'],
 	perPage: 100,
-	terms: { value: 3, unit: 'month' },
+	targetTerm: { value: 1, unit: 'month' },
+	retentionTerm: { value: 3, unit: 'month' },
 } as const;
 const latestReleaseUrl =
 	'https://api.github.com/repos/walk8243/amethyst-electron/releases/latest';

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -104,6 +104,23 @@ export const store = new Store<{
 									},
 								},
 							},
+							reviewers: {
+								type: 'array',
+								items: {
+									type: 'object',
+									properties: {
+										login: {
+											type: 'string',
+										},
+										avatarUrl: {
+											type: 'string',
+										},
+										state: {
+											type: 'string',
+										},
+									},
+								},
+							},
 							updated_at: {
 								type: 'string',
 							},

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -93,8 +93,16 @@ export const store = new Store<{
 							reactions: {
 								type: 'number',
 							},
-							user: {
-								type: 'string',
+							creator: {
+								type: 'object',
+								properties: {
+									login: {
+										type: 'string',
+									},
+									avatarUrl: {
+										type: 'string',
+									},
+								},
 							},
 							updated_at: {
 								type: 'string',

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -1,8 +1,11 @@
+import { app } from 'electron';
 import Store from 'electron-store';
+import semver from 'semver';
 import type { UserInfo } from '../../types/User';
 import type { Issue } from '../../types/Issue';
 
 export const store = new Store<{
+	appVersion: string;
 	githubSetting: { baseUrl: string; token: string };
 	userInfo: UserInfo;
 	issueData: {
@@ -11,6 +14,9 @@ export const store = new Store<{
 	};
 }>({
 	schema: {
+		appVersion: {
+			type: 'string',
+		},
 		githubSetting: {
 			type: 'object',
 			properties: {
@@ -131,3 +137,11 @@ export const store = new Store<{
 		},
 	},
 });
+
+if (
+	!store.get('appVersion') ||
+	semver.gt(app.getVersion(), store.get('appVersion'))
+) {
+	store.delete('userInfo');
+	store.delete('issueData');
+}

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -110,7 +110,7 @@ export const store = new Store<{
 									},
 								},
 							},
-							reviewers: {
+							reviews: {
 								type: 'array',
 								items: {
 									type: 'object',

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -145,3 +145,4 @@ if (
 	store.delete('userInfo');
 	store.delete('issueData');
 }
+store.set('appVersion', app.getVersion());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amethyst",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amethyst",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "関係しているGitHubのIssuesを表示・管理するデスクトップアプリ",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/components/IssueCard.tsx
+++ b/renderer/components/IssueCard.tsx
@@ -50,7 +50,7 @@ export const IssueCard = ({ issue }: { issue: Issue }) => {
 								</Typography>
 							</Grid>
 						</Grid>
-						<Grid container columnGap={1}>
+						<Grid container columnGap={2}>
 							<Grid item>
 								<Avatar
 									alt={issue.creator?.login}
@@ -64,7 +64,7 @@ export const IssueCard = ({ issue }: { issue: Issue }) => {
 								xs
 								zeroMinWidth
 								direction="row-reverse"
-								columnGap={0.5}
+								columnGap={1}
 							>
 								{issue.reviews.map((review) => (
 									<Grid item key={review.login}>

--- a/renderer/components/IssueCard.tsx
+++ b/renderer/components/IssueCard.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import type { MouseEvent } from 'react';
 import { IssueDispatchContext } from '../context/IssueContext';
 import { safeUnreachable } from '../utils/typescript';
-import type { Issue, IssueState, Reviewer } from '../../types/Issue';
+import type { Issue, IssueState, Review } from '../../types/Issue';
 
 import {
 	Avatar,
@@ -66,9 +66,9 @@ export const IssueCard = ({ issue }: { issue: Issue }) => {
 								direction="row-reverse"
 								columnGap={0.5}
 							>
-								{issue.reviewers.map((reviewer) => (
-									<Grid item key={reviewer.login}>
-										<ReviewerAvatar reviewer={reviewer} />
+								{issue.reviews.map((review) => (
+									<Grid item key={review.login}>
+										<ReviewerAvatar review={review} />
 									</Grid>
 								))}
 							</Grid>
@@ -91,17 +91,17 @@ export const IssueCard = ({ issue }: { issue: Issue }) => {
 	);
 };
 
-const ReviewerAvatar = ({ reviewer }: { reviewer: Reviewer }) => {
+const ReviewerAvatar = ({ review }: { review: Review }) => {
 	return (
 		<Badge
-			color={findIssueReviewStateIcon(reviewer.state)}
+			color={findIssueReviewStateIcon(review.state)}
 			overlap="circular"
 			anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
 			variant="dot"
 		>
 			<Avatar
-				alt={reviewer.login}
-				src={reviewer.avatarUrl}
+				alt={review.login}
+				src={review.avatarUrl}
 				sx={{ width: 20, height: 20 }}
 			/>
 		</Badge>
@@ -132,7 +132,7 @@ const findIssueStateColor = (state: IssueState): string => {
 
 	safeUnreachable(state);
 };
-const findIssueReviewStateIcon = (state: Reviewer['state']) => {
+const findIssueReviewStateIcon = (state: Review['state']) => {
 	switch (state) {
 		case 'APPROVED':
 			return 'success';

--- a/renderer/components/IssueCard.tsx
+++ b/renderer/components/IssueCard.tsx
@@ -1,0 +1,146 @@
+import { useContext } from 'react';
+import type { MouseEvent } from 'react';
+import { IssueDispatchContext } from '../context/IssueContext';
+import { safeUnreachable } from '../utils/typescript';
+import type { Issue, IssueState, Reviewer } from '../../types/Issue';
+
+import {
+	Avatar,
+	Badge,
+	Card,
+	CardActionArea,
+	CardContent,
+	Grid,
+	Typography,
+} from '@mui/material';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+	IconDefinition,
+	faCodePullRequest,
+} from '@fortawesome/free-solid-svg-icons';
+import { faCircleDot } from '@fortawesome/free-regular-svg-icons';
+
+export const IssueCard = ({ issue }: { issue: Issue }) => {
+	const dispatch = useContext(IssueDispatchContext);
+	const handleClick = (e: MouseEvent) => {
+		dispatch(issue);
+		window.electron?.issue(issue.url);
+		e.preventDefault();
+	};
+
+	return (
+		<Card sx={{ width: '100%', m: 0.5 }}>
+			<CardActionArea onClick={handleClick}>
+				<CardContent>
+					<Grid container direction="column" rowGap={1}>
+						<Grid container columnGap={1}>
+							<Grid item pt="2px">
+								<FontAwesomeIcon
+									icon={findIssueIcon(issue.state)}
+									color={findIssueStateColor(issue.state)}
+								/>
+							</Grid>
+							<Grid item xs zeroMinWidth>
+								<Typography
+									variant="subtitle1"
+									color="inherit"
+									sx={{ overflowWrap: 'break-word' }}
+								>
+									{issue.title}
+								</Typography>
+							</Grid>
+						</Grid>
+						<Grid container columnGap={1}>
+							<Grid item>
+								<Avatar
+									alt={issue.creator?.login}
+									src={issue.creator?.avatarUrl}
+									sx={{ width: 20, height: 20 }}
+								/>
+							</Grid>
+							<Grid
+								container
+								item
+								xs
+								zeroMinWidth
+								direction="row-reverse"
+								columnGap={0.5}
+							>
+								{issue.reviewers.map((reviewer) => (
+									<Grid item key={reviewer.login}>
+										<ReviewerAvatar reviewer={reviewer} />
+									</Grid>
+								))}
+							</Grid>
+						</Grid>
+						<Grid container columnGap={1}>
+							<Grid container item xs zeroMinWidth>
+								<Typography variant="body2">{issue.repositoryName}</Typography>
+								<Typography
+									variant="body2"
+									sx={{ ml: 1, '::before': { content: '"#"' } }}
+								>
+									{issue.number}
+								</Typography>
+							</Grid>
+						</Grid>
+					</Grid>
+				</CardContent>
+			</CardActionArea>
+		</Card>
+	);
+};
+
+const ReviewerAvatar = ({ reviewer }: { reviewer: Reviewer }) => {
+	return (
+		<Badge
+			color={findIssueReviewStateIcon(reviewer.state)}
+			overlap="circular"
+			anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+			variant="dot"
+		>
+			<Avatar
+				alt={reviewer.login}
+				src={reviewer.avatarUrl}
+				sx={{ width: 20, height: 20 }}
+			/>
+		</Badge>
+	);
+};
+
+const findIssueIcon = (state: IssueState): IconDefinition => {
+	switch (state.type) {
+		case 'issue':
+			return faCircleDot;
+		case 'pull-request':
+			return faCodePullRequest;
+	}
+
+	safeUnreachable(state);
+};
+const findIssueStateColor = (state: IssueState): string => {
+	switch (state.state) {
+		case 'open':
+			return 'green';
+		case 'closed':
+			return 'red';
+		case 'merged':
+			return 'purple';
+		case 'draft':
+			return 'gray';
+	}
+
+	safeUnreachable(state);
+};
+const findIssueReviewStateIcon = (state: Reviewer['state']) => {
+	switch (state) {
+		case 'APPROVED':
+			return 'success';
+		case 'CHANGES_REQUESTED':
+			return 'error';
+		case 'COMMENTED':
+			return 'ordinarily';
+	}
+
+	safeUnreachable(state);
+};

--- a/renderer/components/IssueList.tsx
+++ b/renderer/components/IssueList.tsx
@@ -1,28 +1,14 @@
 import { useContext, useEffect, useState } from 'react';
-import type { MouseEvent } from 'react';
 import { ColorModeContext } from '../context/ColorModeContext';
-import { IssueDispatchContext } from '../context/IssueContext';
 import { IssueFilterContext } from '../context/IssueFilterContext';
 import { UserInfoContext } from '../context/UserContext';
-import { safeUnreachable } from '../utils/typescript';
-import type { Issue, IssueState } from '../../types/Issue';
+import type { Issue } from '../../types/Issue';
 
-import {
-	Avatar,
-	Card,
-	CardActionArea,
-	CardContent,
-	Grid,
-	Typography,
-} from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-	IconDefinition,
-	faCodePullRequest,
-	faSpinner,
-} from '@fortawesome/free-solid-svg-icons';
-import { faCircleDot } from '@fortawesome/free-regular-svg-icons';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { Heading } from './Heading';
+import { IssueCard } from './IssueCard';
 import surface from '../styles/colors/surface';
 
 const numberFormat = Intl.NumberFormat('ja-JP');
@@ -99,106 +85,6 @@ const IssueCards = ({ issues }: { issues: Issue[] | null }) => {
 				))}
 		</Grid>
 	);
-};
-
-const IssueCard = ({ issue }: { issue: Issue }) => {
-	const dispatch = useContext(IssueDispatchContext);
-	const handleClick = (e: MouseEvent) => {
-		dispatch(issue);
-		window.electron?.issue(issue.url);
-		e.preventDefault();
-	};
-
-	return (
-		<Card sx={{ width: '100%', m: 0.5 }}>
-			<CardActionArea onClick={handleClick}>
-				<CardContent>
-					<Grid container direction="column" rowGap={1}>
-						<Grid container columnGap={1}>
-							<Grid item pt="2px">
-								<FontAwesomeIcon
-									icon={findIssueIcon(issue.state)}
-									color={findIssueStateColor(issue.state)}
-								/>
-							</Grid>
-							<Grid item xs zeroMinWidth>
-								<Typography
-									variant="subtitle1"
-									color="inherit"
-									sx={{ overflowWrap: 'break-word' }}
-								>
-									{issue.title}
-								</Typography>
-							</Grid>
-						</Grid>
-						<Grid container columnGap={1}>
-							<Grid item>
-								<Avatar
-									alt={issue.creator?.login}
-									src={issue.creator?.avatarUrl}
-									sx={{ width: 20, height: 20 }}
-								/>
-							</Grid>
-							<Grid
-								container
-								item
-								xs
-								zeroMinWidth
-								direction="row-reverse"
-								columnGap={0.5}
-							>
-								{issue.reviewers.map((reviewer) => (
-									<Grid item key={reviewer.login}>
-										<Avatar
-											alt={reviewer.login}
-											src={reviewer.avatarUrl}
-											sx={{ width: 20, height: 20 }}
-										/>
-									</Grid>
-								))}
-							</Grid>
-						</Grid>
-						<Grid container columnGap={1}>
-							<Grid container item xs zeroMinWidth>
-								<Typography variant="body2">{issue.repositoryName}</Typography>
-								<Typography
-									variant="body2"
-									sx={{ ml: 1, '::before': { content: '"#"' } }}
-								>
-									{issue.number}
-								</Typography>
-							</Grid>
-						</Grid>
-					</Grid>
-				</CardContent>
-			</CardActionArea>
-		</Card>
-	);
-};
-
-const findIssueIcon = (state: IssueState): IconDefinition => {
-	switch (state.type) {
-		case 'issue':
-			return faCircleDot;
-		case 'pull-request':
-			return faCodePullRequest;
-	}
-
-	safeUnreachable(state);
-};
-const findIssueStateColor = (state: IssueState): string => {
-	switch (state.state) {
-		case 'open':
-			return 'green';
-		case 'closed':
-			return 'red';
-		case 'merged':
-			return 'purple';
-		case 'draft':
-			return 'gray';
-	}
-
-	safeUnreachable(state);
 };
 
 export default IssueList;

--- a/renderer/components/IssueList.tsx
+++ b/renderer/components/IssueList.tsx
@@ -139,7 +139,24 @@ const IssueCard = ({ issue }: { issue: Issue }) => {
 									sx={{ width: 20, height: 20 }}
 								/>
 							</Grid>
-							<Grid item xs zeroMinWidth></Grid>
+							<Grid
+								container
+								item
+								xs
+								zeroMinWidth
+								direction="row-reverse"
+								columnGap={0.5}
+							>
+								{issue.reviewers.map((reviewer) => (
+									<Grid item key={reviewer.login}>
+										<Avatar
+											alt={reviewer.login}
+											src={reviewer.avatarUrl}
+											sx={{ width: 20, height: 20 }}
+										/>
+									</Grid>
+								))}
+							</Grid>
 						</Grid>
 						<Grid container columnGap={1}>
 							<Grid container item xs zeroMinWidth>

--- a/renderer/components/IssueList.tsx
+++ b/renderer/components/IssueList.tsx
@@ -8,6 +8,7 @@ import { safeUnreachable } from '../utils/typescript';
 import type { Issue, IssueState } from '../../types/Issue';
 
 import {
+	Avatar,
 	Card,
 	CardActionArea,
 	CardContent,
@@ -112,31 +113,44 @@ const IssueCard = ({ issue }: { issue: Issue }) => {
 		<Card sx={{ width: '100%', m: 0.5 }}>
 			<CardActionArea onClick={handleClick}>
 				<CardContent>
-					<Grid container columnGap={1}>
-						<Grid item pt="2px">
-							<FontAwesomeIcon
-								icon={findIssueIcon(issue.state)}
-								color={findIssueStateColor(issue.state)}
-							/>
+					<Grid container direction="column" rowGap={1}>
+						<Grid container columnGap={1}>
+							<Grid item pt="2px">
+								<FontAwesomeIcon
+									icon={findIssueIcon(issue.state)}
+									color={findIssueStateColor(issue.state)}
+								/>
+							</Grid>
+							<Grid item xs zeroMinWidth>
+								<Typography
+									variant="subtitle1"
+									color="inherit"
+									sx={{ overflowWrap: 'break-word' }}
+								>
+									{issue.title}
+								</Typography>
+							</Grid>
 						</Grid>
-						<Grid item xs zeroMinWidth>
-							<Typography
-								variant="subtitle1"
-								sx={{ overflowWrap: 'break-word' }}
-							>
-								{issue.title}
-							</Typography>
+						<Grid container columnGap={1}>
+							<Grid item>
+								<Avatar
+									alt={issue.creator?.login}
+									src={issue.creator?.avatarUrl}
+									sx={{ width: 20, height: 20 }}
+								/>
+							</Grid>
+							<Grid item xs zeroMinWidth></Grid>
 						</Grid>
-					</Grid>
-					<Grid container columnGap={1}>
-						<Grid container item xs zeroMinWidth>
-							<Typography variant="body2">{issue.repositoryName}</Typography>
-							<Typography
-								variant="body2"
-								sx={{ ml: 1, '::before': { content: '"#"' } }}
-							>
-								{issue.number}
-							</Typography>
+						<Grid container columnGap={1}>
+							<Grid container item xs zeroMinWidth>
+								<Typography variant="body2">{issue.repositoryName}</Typography>
+								<Typography
+									variant="body2"
+									sx={{ ml: 1, '::before': { content: '"#"' } }}
+								>
+									{issue.number}
+								</Typography>
+							</Grid>
 						</Grid>
 					</Grid>
 				</CardContent>

--- a/renderer/context/ColorModeContext.ts
+++ b/renderer/context/ColorModeContext.ts
@@ -3,6 +3,7 @@ import type { PaletteMode, PaletteOptions } from '@mui/material';
 import { error } from '../styles/colors/error';
 import { primary } from '../styles/colors/primary';
 import { secondary } from '../styles/colors/secondary';
+import { grey } from '@mui/material/colors';
 
 export const ColorModeContext = createContext<PaletteMode>('light');
 export const ColorModeDispatchContext = createContext<Dispatch<PaletteMode>>(
@@ -26,6 +27,12 @@ export const colorSetting: PaletteOptions = {
 		main: error.key,
 		light: error.light.main,
 		dark: error.dark.main,
+		contrastText: '#fff',
+	},
+	ordinarily: {
+		main: grey[500],
+		light: grey[300],
+		dark: grey[700],
 		contrastText: '#fff',
 	},
 };

--- a/renderer/context/IssueFilterContext.ts
+++ b/renderer/context/IssueFilterContext.ts
@@ -74,8 +74,8 @@ export const fromFilterType = (type: IssueFilterTypes): IssueFilter => {
 };
 
 const checkOwnIssue = (issue: Issue, user: UserInfo | null) => {
-	if (!issue.user || !user) {
+	if (!issue.creator || !user) {
 		return false;
 	}
-	return issue.user === user.login;
+	return issue.creator.login === user.login;
 };

--- a/renderer/styles/mui.d.ts
+++ b/renderer/styles/mui.d.ts
@@ -1,0 +1,15 @@
+import '@mui/material';
+
+declare module '@mui/material/styles' {
+	interface Palette {
+		ordinarily: Palette['primary'];
+	}
+	interface PaletteOptions {
+		ordinarily?: PaletteOptions['primary'];
+	}
+}
+declare module '@mui/material/Badge' {
+	interface BadgePropsColorOverrides {
+		ordinarily: true;
+	}
+}

--- a/types/Issue.d.ts
+++ b/types/Issue.d.ts
@@ -9,6 +9,7 @@ export interface Issue {
 	labels: IssueLabel[];
 	reactions: number;
 	creator: UserInfo | null;
+	reviewers: Reviewer[];
 	updatedAt: string;
 }
 
@@ -25,4 +26,10 @@ export interface IssueLabel {
 export interface UserInfo {
 	login: string;
 	avatarUrl: string;
+}
+
+export interface Reviewer {
+	login: string;
+	avatarUrl: string;
+	state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED';
 }

--- a/types/Issue.d.ts
+++ b/types/Issue.d.ts
@@ -8,7 +8,7 @@ export interface Issue {
 	state: IssueState;
 	labels: IssueLabel[];
 	reactions: number;
-	user: string | null;
+	creator: UserInfo | null;
 	updatedAt: string;
 }
 
@@ -20,4 +20,9 @@ export interface IssueLabel {
 	key: string | null;
 	text: string;
 	color: string | null;
+}
+
+export interface UserInfo {
+	login: string;
+	avatarUrl: string;
 }

--- a/types/Issue.d.ts
+++ b/types/Issue.d.ts
@@ -9,7 +9,7 @@ export interface Issue {
 	labels: IssueLabel[];
 	reactions: number;
 	creator: UserInfo | null;
-	reviewers: Reviewer[];
+	reviews: Review[];
 	updatedAt: string;
 }
 
@@ -28,7 +28,7 @@ export interface UserInfo {
 	avatarUrl: string;
 }
 
-export interface Reviewer {
+export interface Review {
 	login: string;
 	avatarUrl: string;
 	state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED';


### PR DESCRIPTION
# 概要

PRのレビュー状況をAvatarとBadgeで分かるようにする

# 詳細

- Issueのカードにレビュー状況をAvatarとBadgeで視覚的に分かるようにする
- 最後に叩いたときからの差分のみをGitHubに問い合わせるようにする

# 期待値

- [x] レビュー状況が一覧の状態で分かる
