### PR TITLE
軽いデザイン調整

### DIFF
--- a/renderer/components/IssueCard.tsx
+++ b/renderer/components/IssueCard.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import type { MouseEvent } from 'react';
-import { IssueDispatchContext } from '../context/IssueContext';
+import { IssueContext, IssueDispatchContext } from '../context/IssueContext';
 import { safeUnreachable } from '../utils/typescript';
 import type { Issue, IssueState, Review } from '../../types/Issue';
 
@@ -21,6 +21,7 @@ import {
 import { faCircleDot } from '@fortawesome/free-regular-svg-icons';
 
 export const IssueCard = ({ issue }: { issue: Issue }) => {
+	const selectedIssue = useContext(IssueContext);
 	const dispatch = useContext(IssueDispatchContext);
 	const handleClick = (e: MouseEvent) => {
 		dispatch(issue);
@@ -29,7 +30,10 @@ export const IssueCard = ({ issue }: { issue: Issue }) => {
 	};
 
 	return (
-		<Card sx={{ width: '100%', m: 0.5 }}>
+		<Card
+			raised={issue.key === selectedIssue?.key}
+			sx={{ width: '100%', m: 0.5 }}
+		>
 			<CardActionArea onClick={handleClick}>
 				<CardContent>
 					<Grid container direction="column" rowGap={1}>

--- a/renderer/components/IssueList.tsx
+++ b/renderer/components/IssueList.tsx
@@ -74,6 +74,9 @@ const IssueCards = ({ issues }: { issues: Issue[] | null }) => {
 	return (
 		<Grid
 			container
+			alignContent="flex-start"
+			alignItems="flex-start"
+			rowGap={1}
 			p={1}
 			bgcolor={surface.container[colorMode].main}
 			sx={{ overflowY: 'auto' }}
@@ -81,7 +84,9 @@ const IssueCards = ({ issues }: { issues: Issue[] | null }) => {
 			{issues
 				.filter((issue) => issueFilter.filter(issue, { user: userInfo }))
 				.map((issue) => (
-					<IssueCard key={issue.key} issue={issue} />
+					<Grid item key={issue.key} xs={12}>
+						<IssueCard issue={issue} />
+					</Grid>
 				))}
 		</Grid>
 	);

--- a/renderer/components/Menu.tsx
+++ b/renderer/components/Menu.tsx
@@ -84,14 +84,16 @@ const Filters = () => {
 	return (
 		<Grid container item width="100%">
 			<Grid item width="100%">
-				<Typography variant="subtitle1">Library</Typography>
-				<List sx={{ px: 2 }}>
+				<Typography variant="subtitle1" mb={1}>
+					Library
+				</Typography>
+				<List sx={{ px: 2, py: 0 }}>
 					{issueFilters.map((filter) => (
-						<ListItem key={filter.type} sx={{ p: 0 }}>
+						<ListItem key={filter.type} sx={{ my: 1, p: 0 }}>
 							<ListItemButton
 								onClick={(_e) => issueFilterDispatch(filter)}
 								selected={filter.type === issueFilter.type}
-								sx={{ p: '3px' }}
+								sx={{ p: '3px', borderRadius: 1 }}
 							>
 								<ListItemIcon sx={{ minWidth: 'initial', mr: 2 }}>
 									<FontAwesomeIcon icon={filter.icon} />


### PR DESCRIPTION
# 概要

Menuの余白や選択しているIssueの可視化や表示するIssueが少ないときの表示を調整

# 詳細

- Menuの余白をかっちり合わせる
- 選択しているIssueだけ持ち上げるデザインにする
- 表示するIssueが少ないときでも上詰めで表示するようにする
