### PR TITLE
READMEに記載を追加

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,6 +34,50 @@
 				"showReuseMessage": true,
 				"clear": false
 			}
+		},
+		{
+			"type": "npm",
+			"script": "lint",
+			"problemMatcher": [],
+			"label": "lint",
+			"detail": "lint",
+			"presentation": {
+				"echo": true,
+				"reveal": "silent",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": false
+			}
+		},
+		{
+			"type": "npm",
+			"script": "type-check",
+			"problemMatcher": [],
+			"label": "type-check",
+			"detail": "type-check",
+			"presentation": {
+				"echo": true,
+				"reveal": "silent",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": false
+			}
+		},
+		{
+			"label": "check",
+			"problemMatcher": [],
+			"dependsOrder": "sequence",
+			"dependsOn": ["lint", "type-check"],
+			"presentation": {
+				"echo": true,
+				"reveal": "silent",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": false
+			}
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -6,13 +6,56 @@
 
 ## 使い方
 
+### インストール
+
+#### Macの場合
+
+Homebrew Caskを用意しています。
+以下のコマンドにて、インストールしてください。
+
+```sh
+brew tap --cask @walk8243/cask
+brew install --cask @walk8243/cask/amethyst
+```
+
+インストール後、起動するためには **システム設定** > **プライバシーとセキュリティ** でAmethystを許可してください。
+
+#### Windowsの場合
+
+Windowsインストーラファイル `*.msi` を用意しています。
+[最新のリリース](https://github.com/walk8243/amethyst-electron/releases/) からインストーラをダウンロードしてください。
+
+ダウンロード完了後は、エクスプローラなどからダブルクリックしてインストールしてください。
+
+以下はPowershellから操作するときの例です。
+
+```pwsh
+# インストールする場合
+msiexec.exe /i "$env:userprofile\Downloads\amethyst-0.0.0-win.msi"
+
+# アンインストールする場合
+msiexec.exe /x "$env:userprofile\Downloads\amethyst-0.0.0-win.msi"
+```
+
 ### 初期設定
+
+使用するには、GitHub Tokenが必要になります。
+
+こちら https://github.com/settings/tokens からTokenを取得してください。
+
+## 開発者用
+
+VSCode用の設定は作成済みです。
+
+### コマンド
+
+#### 初期設定
 
 ```bash
 $ npm ci
 ```
 
-### 本番環境のビルド
+#### 本番環境のビルド
 
 ```bash
 $ npm run dist
@@ -20,19 +63,27 @@ $ npm run dist
 
 注）PCの設定によっては、管理者権限が必要になることがあります。
 
-### 開発時の起動
+#### 開発時の起動
+
+VSCodeのDebuggerからも起動できます。
 
 ```bash
 $ npm run dev
 ```
 
-### TypeScriptの型チェック
+#### 検証
+
+VSCodeの `check` taskから実行できます。
 
 ```bash
+# 型チェック
 $ npm run type-check
+
+# Lint
+$ npm run lint
 ```
 
-## TypeScript × Next.js × Electron
+### アプリケーション構成
 
 Electronアプリケーション内でNext.jsを使用しています。
 多くの設定をしないために、Next.jsをルーティングに使用し、アプリケーションの初期レンダリングを高速化するためにサーバサイドレンダリングを活用しています。
@@ -47,14 +98,9 @@ Next.jsもElectronレイヤもTypeScriptで記述され、ビルド時にJavaScr
 開発時は、HTTPサーバを起動し、Next.jsでルーティングしています。
 本番環境では、HTTPサーバを起動する代わりに、静的なHTMLファイルを `output: 'export'` で事前に生成し使用しています。
 
-### インストール方法
+### デザイン
 
-```bash
-$ npx create-next-app --example with-electron-typescript with-electron-typescript-app
-```
-
-## 開発
-
-### Figma
+Figmaを用いて画面デザインを作成しています。
+デザインフレームワークはMaterialDesignです。
 
 https://www.figma.com/file/yQLWa7vdPFTJxUUPtUGsmj/amethyst-electron?type=design&t=40RWPyne71Apt9tS-6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amethyst",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amethyst",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "関係しているGitHubのIssuesを表示・管理するデスクトップアプリ",
   "main": "main/index.js",
   "scripts": {


### PR DESCRIPTION
# 概要

READMEにインストール方法や開発者用の導入を調整

# 詳細

- インストール方法をMacとWindows両方を記載
- git clone後の起動方法を記載
- VSCodeのtaskの設定を追加
