### PR TITLE
ブラウザのback, forwardのボタンの有効・無効を切り替える

### DIFF
--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -91,21 +91,32 @@ const setupWebview = (mainWindow: BrowserWindow) => {
 	ipcMain.on('browser:open', (_event, url: string) => {
 		shell.openExternal(url);
 	});
-	ipcMain.handle('browser:back', (_event) => {
-		webview.webContents.goBack();
-	});
-	ipcMain.handle('browser:forward', (_event) => {
-		webview.webContents.goForward();
-	});
 	ipcMain.handle('browser:reload', (_event) => {
 		webview.webContents.reload();
+	});
+	ipcMain.handle('browser:history', (_event, ope: 'back' | 'forward') => {
+		if (ope === 'back') {
+			webview.webContents.goBack();
+		}
+		if (ope === 'forward') {
+			webview.webContents.goForward();
+		}
+
+		return {
+			canGoBack: webview.webContents.canGoBack(),
+			canGoForward: webview.webContents.canGoForward(),
+		};
 	});
 	ipcMain.on('browser:copy', (_event, url: string) => {
 		clipboard.writeText(url);
 	});
 
 	webview.webContents.on('did-finish-load', () => {
-		mainWindow.webContents.send('browser:load', webview.webContents.getURL());
+		mainWindow.webContents.send('browser:load', {
+			url: webview.webContents.getURL(),
+			canGoBack: webview.webContents.canGoBack(),
+			canGoForward: webview.webContents.canGoForward(),
+		});
 	});
 	return webview;
 };

--- a/electron-src/preload/main.ts
+++ b/electron-src/preload/main.ts
@@ -5,12 +5,17 @@ import type { Issue } from '../../types/Issue';
 contextBridge.exposeInMainWorld('electron', {
 	issue: (url: string) => ipcRenderer.invoke('github:issue', url),
 	open: (url: string) => ipcRenderer.send('browser:open', url),
-	goBack: () => ipcRenderer.invoke('browser:back'),
-	goForward: () => ipcRenderer.invoke('browser:forward'),
 	reload: () => ipcRenderer.invoke('browser:reload'),
+	history: (ope: 'back' | 'forward') =>
+		ipcRenderer.invoke('browser:history', ope),
 	copy: (url: string) => ipcRenderer.send('browser:copy', url),
-	load: (callback: (url: string) => void) =>
-		ipcRenderer.on('browser:load', (_event, value) => callback(value)),
+	load: (
+		callback: (value: {
+			url: string;
+			canGoBack: boolean;
+			canGoForward: boolean;
+		}) => void,
+	) => ipcRenderer.on('browser:load', (_event, value) => callback(value)),
 
 	ready: () => ipcRenderer.send('app:ready'),
 	pushUser: (callback: (user: UserInfo) => void) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amethyst",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amethyst",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "関係しているGitHubのIssuesを表示・管理するデスクトップアプリ",
   "main": "main/index.js",
   "scripts": {

--- a/renderer/components/Viewer.tsx
+++ b/renderer/components/Viewer.tsx
@@ -37,11 +37,16 @@ const Viewer = () => {
 
 const IssueUrlBar = () => {
 	const [url, setUrl] = useState<string | null>(null);
-	const handleBack = () => {
-		window.electron?.goBack();
-	};
-	const handleForward = () => {
-		window.electron?.goForward();
+	const [canGo, setCanGo] = useState<{ back: boolean; forward: boolean }>({
+		back: false,
+		forward: false,
+	});
+	const handleHistory = async (direction: 'back' | 'forward') => {
+		const result = (await window.electron?.history(direction)) ?? {
+			canGoBack: false,
+			canGoForward: false,
+		};
+		setCanGo({ back: result.canGoBack, forward: result.canGoForward });
 	};
 	const handleReload = () => {
 		window.electron?.reload();
@@ -52,7 +57,10 @@ const IssueUrlBar = () => {
 	};
 
 	useEffect(() => {
-		window.electron?.load(setUrl);
+		window.electron?.load(({ url, canGoBack, canGoForward }) => {
+			setUrl(url);
+			setCanGo({ back: canGoBack, forward: canGoForward });
+		});
 	}, []);
 
 	return (
@@ -61,12 +69,20 @@ const IssueUrlBar = () => {
 				Issue URLバー
 			</Heading>
 			<Grid item>
-				<IconButton onClick={handleBack} size="small">
+				<IconButton
+					onClick={() => handleHistory('back')}
+					size="small"
+					disabled={!canGo.back}
+				>
 					<FontAwesomeIcon icon={faArrowLeft} />
 				</IconButton>
 			</Grid>
 			<Grid item>
-				<IconButton onClick={handleForward} size="small">
+				<IconButton
+					onClick={() => handleHistory('forward')}
+					size="small"
+					disabled={!canGo.forward}
+				>
 					<FontAwesomeIcon icon={faArrowRight} />
 				</IconButton>
 			</Grid>

--- a/renderer/interfaces/index.ts
+++ b/renderer/interfaces/index.ts
@@ -6,11 +6,18 @@ declare global {
 		electron: {
 			issue: (url: string) => Promise<void>;
 			open: (url: string) => void;
-			goBack: () => void;
-			goForward: () => void;
 			reload: () => void;
+			history: (
+				ope: 'back' | 'forward',
+			) => Promise<{ canGoBack: boolean; canGoForward: boolean }>;
 			copy: (url: string) => void;
-			load: (callback: (url: string) => void) => void;
+			load: (
+				callback: (value: {
+					url: string;
+					canGoBack: boolean;
+					canGoForward: boolean;
+				}) => void,
+			) => void;
 			ready: () => void;
 			pushUser: (callback: (user: UserInfo) => void) => void;
 			pushIssues: (callback: (issues: Issue[]) => void) => void;


### PR DESCRIPTION
# 概要

ブラウザの戻る・進むボタンを、操作が可能なときだけ有効になるようにする。

# 詳細

- ブラウザの戻るボタンが使えないときは無効になる
- ブラウザの進むボタンが使えないときは無効になる
