### PR TITLE
アプリメニューを日本語化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amethyst",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amethyst",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "関係しているGitHubのIssuesを表示・管理するデスクトップアプリ",
   "main": "main/index.js",
   "scripts": {


### PR DESCRIPTION
# 概要

アプリメニューを日本語化してOSごとにメニューを切り替え

# 詳細

- アプリメニューの日本語化
- アプリメニューをMacとWindowsで表示分け
