### PR TITLE
Issueをメニューから取得して更新できるようにする

### DIFF
--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -21,6 +21,7 @@ let latestIssueGainTime: dayjs.Dayjs = ((date: string) => {
 			);
 })(store.get('issueData')?.updatedAt);
 let issueTimer: NodeJS.Timeout;
+let isBlockGainIssues: boolean = false;
 
 export const gainGithubAllData = async (isBoot: boolean) => {
 	log.debug('main.gainGithubAllData を実行します');
@@ -49,6 +50,9 @@ export const gainGithubUser = async () => {
 };
 export const gainGithubIssues = async () => {
 	log.debug('main.gainGithubIssues を実行します');
+	if (isBlockGainIssues) return;
+	isBlockGainIssues = true;
+
 	const now = dayjs();
 	const issues = await gainIssues(latestIssueGainTime);
 
@@ -69,6 +73,9 @@ export const gainGithubIssues = async () => {
 		notification.show();
 	}
 
+	setTimeout(() => {
+		isBlockGainIssues = false;
+	}, 5000);
 	return issues;
 };
 

--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -11,6 +11,7 @@ import {
 import { store } from './utils/store';
 import { Issue } from '../types/Issue';
 
+const IssueGainInterval = 300000 as const; // 5分
 let latestIssueGainTime: dayjs.Dayjs = ((date: string) => {
 	return date
 		? dayjs(date)
@@ -19,6 +20,7 @@ let latestIssueGainTime: dayjs.Dayjs = ((date: string) => {
 				githubAppSettings.targetTerm.unit,
 			);
 })(store.get('issueData')?.updatedAt);
+let issueTimer: NodeJS.Timeout;
 
 export const gainGithubAllData = async (isBoot: boolean) => {
 	log.debug('main.gainGithubAllData を実行します');
@@ -68,6 +70,17 @@ export const gainGithubIssues = async () => {
 	}
 
 	return issues;
+};
+
+export const scheduledGainGithubIssues = () => {
+	issueTimer = setInterval(() => {
+		gainGithubIssues();
+	}, IssueGainInterval);
+};
+export const refreshIssueTimer = () => {
+	if (issueTimer) {
+		issueTimer.refresh();
+	}
 };
 
 export const checkUpdate = async () => {

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -17,14 +17,16 @@ import installExtension, {
 	REACT_DEVELOPER_TOOLS,
 } from 'electron-devtools-installer';
 
-import { checkUpdate, gainGithubAllData, gainGithubIssues } from './github';
+import {
+	checkUpdate,
+	gainGithubAllData,
+	scheduledGainGithubIssues,
+} from './github';
 import { createMenu } from './menu';
 import { checkStoreData } from './utils/github';
 import { getLoadedUrl } from './utils/render';
 import { store } from './utils/store';
 import * as windowUtils from './utils/window';
-
-const IssueGainInterval = 300000 as const; // 5分
 
 export const main = async () => {
 	const mainWindow = setupMainWindow();
@@ -40,10 +42,7 @@ export const main = async () => {
 	setupModalWindow(mainWindow, webview, storeDataFlag.isInvalid());
 	setupResizedSetting(mainWindow, webview);
 
-	setInterval(() => {
-		gainGithubIssues();
-	}, IssueGainInterval);
-
+	scheduledGainGithubIssues();
 	await announceUpdate(mainWindow);
 	await setupDevtools();
 };

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -138,7 +138,6 @@ const setupModalWindow = (
 	const settingWindow = windowUtils.createSetting(mainWindow);
 	const aboutWindow = windowUtils.createAbout(mainWindow);
 	const menu = createMenu({
-		parentWindow: mainWindow,
 		webview,
 		settingWindow,
 		aboutWindow,

--- a/electron-src/menu.ts
+++ b/electron-src/menu.ts
@@ -9,7 +9,11 @@ import {
 } from 'electron';
 import isDev from 'electron-is-dev';
 
-import { gainGithubAllData, gainGithubIssues } from './github';
+import {
+	gainGithubAllData,
+	gainGithubIssues,
+	refreshIssueTimer,
+} from './github';
 import { store } from './utils/store';
 import type { SettingData } from './preload/setting';
 
@@ -160,6 +164,7 @@ const viewMenu = ({
 		accelerator: 'CmdOrCtrl+Shift+R',
 		click: () => {
 			gainGithubIssues();
+			refreshIssueTimer();
 		},
 	},
 	...viewDevMenu(),

--- a/electron-src/menu.ts
+++ b/electron-src/menu.ts
@@ -9,19 +9,17 @@ import {
 } from 'electron';
 import isDev from 'electron-is-dev';
 
-import { gainGithubAllData } from './github';
+import { gainGithubAllData, gainGithubIssues } from './github';
 import { store } from './utils/store';
 import type { SettingData } from './preload/setting';
 
 const isMac = process.platform === ('darwin' as const);
 
 export const createMenu = ({
-	parentWindow,
 	webview,
 	settingWindow,
 	aboutWindow,
 }: {
-	parentWindow: BrowserWindow;
 	settingWindow: BrowserWindow;
 	aboutWindow: BrowserWindow;
 	webview: BrowserView;
@@ -41,7 +39,7 @@ export const createMenu = ({
 		},
 		{
 			label: '表示',
-			submenu: viewMenu({ parentWindow, webview }),
+			submenu: viewMenu({ webview }),
 		},
 		{
 			label: 'ウィンドウ',
@@ -148,10 +146,8 @@ const editMenu = (): MenuItemConstructorOptions[] => [
 ];
 
 const viewMenu = ({
-	parentWindow,
 	webview,
 }: {
-	parentWindow: BrowserWindow;
 	webview: BrowserView;
 }): MenuItemConstructorOptions[] => [
 	{
@@ -162,8 +158,9 @@ const viewMenu = ({
 	{
 		label: 'Issueを再読み込み',
 		accelerator: 'CmdOrCtrl+Shift+R',
-		enabled: false,
-		click: () => parentWindow.reload(),
+		click: () => {
+			gainGithubIssues();
+		},
 	},
 	...viewDevMenu(),
 	{ type: 'separator' },


### PR DESCRIPTION
# 概要

メニューから取得して、Issueのリストを更新する。

# 詳細

- メニューからGitHubのIssueを取得する
- Issueを取得しにいくのを制御する
