### PR TITLE
GitHub Actions経由でversionを更新してtagを切る

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,36 @@
+name: Package Version UP
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version Category to be updated'
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+        default: minor
+
+jobs:
+  verup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup git user
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - name: verup
+        run: npm version ${{ inputs.version }}
+      - name: git push
+        run: |
+          git push
+          git push --tags
+    env:
+      GH_TOKEN: ${{ github.token }}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "dist": "npm run build && electron-builder",
     "type-check": "tsc -p ./renderer/tsconfig.json && tsc -p ./electron-src/tsconfig.json",
     "lint": "eslint electron-src/ renderer/ types/ --ext .ts,.tsx",
-    "lint:fix": "eslint electron-src/ renderer/ types/ --fix --ext .ts,.tsx",
-    "verup": "npm version --no-git-tag-version"
+    "lint:fix": "eslint electron-src/ renderer/ types/ --fix --ext .ts,.tsx"
   },
   "homepage": "https://walk8243.github.io/amethyst-electron/",
   "keywords": [


### PR DESCRIPTION
# 概要

GitHub Actions経由でversionを更新してtagを切るフローを策定

# 詳細

- GitHub Actions経由でversionを更新する
- GitHub Actions経由でtagを切る
