### PR TITLE
ネットワークエラー時のエラー処理を修正

### DIFF
--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -22,9 +22,7 @@ export const gainGithubAllData = async (isBoot: boolean) => {
 	try {
 		await Promise.all([gainGithubUser(), gainGithubIssues()]);
 	} catch (error) {
-		log.error(
-			new Error('GitHub APIからのデータ取得に失敗しました', { cause: error }),
-		);
+		log.error('GitHub APIからのデータ取得に失敗しました', error);
 		if (isBoot) {
 			ipcMain.once('app:ready', () => {
 				showErrorDialog();
@@ -71,7 +69,9 @@ export const gainGithubIssues = async () => {
 
 export const scheduledGainGithubIssues = () => {
 	issueTimer = setInterval(() => {
-		gainGithubIssues();
+		gainGithubIssues().catch((error) => {
+			log.warn('Issueの定期取得に失敗しました', error);
+		});
 	}, IssueGainInterval);
 };
 export const refreshIssueTimer = () => {

--- a/electron-src/github.ts
+++ b/electron-src/github.ts
@@ -44,27 +44,29 @@ export const gainGithubUser = async () => {
 };
 export const gainGithubIssues = async () => {
 	log.debug('main.gainGithubIssues を実行します');
-	if (isBlockGainIssues) return;
-	isBlockGainIssues = true;
+	try {
+		if (isBlockGainIssues) return;
+		isBlockGainIssues = true;
 
-	const now = dayjs();
-	const issues = await gainIssues(latestIssueGainTime);
+		const now = dayjs();
+		const issues = await gainIssues(latestIssueGainTime);
 
-	latestIssueGainTime = now;
-	store.set('issueData', {
-		updatedAt: now.toISOString(),
-		issues: joinIssueData(issues),
-	});
+		latestIssueGainTime = now;
+		store.set('issueData', {
+			updatedAt: now.toISOString(),
+			issues: joinIssueData(issues),
+		});
 
-	if (issues.length > 0) {
-		updateIssueSupplementMap(issues);
-		noticeIssues();
+		if (issues.length > 0) {
+			updateIssueSupplementMap(issues);
+			noticeIssues();
+		}
+		return issues;
+	} finally {
+		setTimeout(() => {
+			isBlockGainIssues = false;
+		}, 5000);
 	}
-
-	setTimeout(() => {
-		isBlockGainIssues = false;
-	}, 5000);
-	return issues;
 };
 
 export const scheduledGainGithubIssues = () => {

--- a/electron-src/menu.ts
+++ b/electron-src/menu.ts
@@ -6,8 +6,10 @@ import {
 	MenuItemConstructorOptions,
 	safeStorage,
 	shell,
+	dialog,
 } from 'electron';
 import isDev from 'electron-is-dev';
+import log from 'electron-log/main';
 
 import {
 	gainGithubAllData,
@@ -168,8 +170,14 @@ const viewMenu = ({
 		label: 'Issueを再読み込み',
 		accelerator: 'CmdOrCtrl+Shift+R',
 		click: () => {
-			gainGithubIssues();
-			refreshIssueTimer();
+			gainGithubIssues()
+				.then((_issues) => {
+					refreshIssueTimer();
+				})
+				.catch((error) => {
+					log.warn('Issueの手動取得に失敗しました', error);
+					dialog.showErrorBox('Issueの取得に失敗しました', error.message);
+				});
 		},
 	},
 	...viewDevMenu(),

--- a/electron-src/utils/error.ts
+++ b/electron-src/utils/error.ts
@@ -29,7 +29,9 @@ const sendError = (error: ErrorData, mainWindow: BrowserWindow) => {
 	mainWindow.webContents.send('error:show', error);
 };
 const viewReportIssue = (webview: BrowserView) => {
-	webview.webContents.loadURL(CREATE_ISSUE_URL);
+	webview.webContents.loadURL(CREATE_ISSUE_URL).catch((error) => {
+		log.error('エラー報告用のIssueを表示できませんでした', error);
+	});
 };
 const showErrorDialog = (mainWindow: BrowserWindow) => {
 	dialog.showMessageBox(mainWindow, {


### PR DESCRIPTION
# 概要

ネットワークエラー時にdeadlockしないように処理を修正しました。

# 詳細

- ネットワークエラー時にもlock処理を解除する
- Issue取得処理中のエラーをちゃんと処理する
- 報告用のIssueを開く処理で処理落ちさせない
