### PR TITLE
reset-cssの読み込み方をnpm経由に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-react": "^7.33.2",
+        "modern-css-reset": "^1.4.0",
         "next": "^14.0.4",
         "png2icons": "^2.0.1",
         "prettier": "^3.2.2",
@@ -5865,6 +5866,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/modern-css-reset": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/modern-css-reset/-/modern-css-reset-1.4.0.tgz",
+      "integrity": "sha512-0crZmSFmrxkI7159rvQWjpDhy0u4+Awg/iOycJdlVn0RSeft/a+6BrQHR3IqvmdK25sqt0o6Z5Ap7cWgUee2rw==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "^7.33.2",
+    "modern-css-reset": "^1.4.0",
     "next": "^14.0.4",
     "png2icons": "^2.0.1",
     "prettier": "^3.2.2",

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -10,6 +10,7 @@ import {
 	colorSetting,
 } from '../context/ColorModeContext';
 
+import 'modern-css-reset';
 import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';

--- a/renderer/pages/_document.tsx
+++ b/renderer/pages/_document.tsx
@@ -5,10 +5,6 @@ export default function Document() {
 		<Html>
 			<Head>
 				<meta charSet="utf-8" />
-				<link
-					rel="stylesheet"
-					href="https://unpkg.com/modern-css-reset/dist/reset.min.css"
-				/>
 			</Head>
 			<body>
 				<Main />


### PR DESCRIPTION
# 概要

reset-cssの読み込み方を、CDN経由からnpm package経由に変更しました。

# 詳細

- ネットワークエラー時にstyleが崩れる問題を解消
- [modern-css-reset](https://github.com/Andy-set-studio/modern-css-reset) の読み込みを `npm package` 経由に変更

# 期待値

- [x] ネットワークエラー時にも表示崩れしない
- [x] styleに変更がない
