### PR TITLE
RateLimitのための設定の見直し

### DIFF
--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -6,12 +6,7 @@ import {
 	translateUserInfo,
 	translateIssues,
 } from '../tanslators/GithubTranslator';
-import {
-	CustomQueueClass,
-	QUEUE_CONCURRENCY,
-	QUEUE_INTERVAL,
-	QUEUE_INTERVAL_CAP,
-} from './queue';
+import { QUEUE_CONCURRENCY, QUEUE_INTERVAL, QUEUE_INTERVAL_CAP } from './queue';
 import { store } from './store';
 import StoreDataFlag from '../enum/StoreDataFlag';
 import type {
@@ -27,7 +22,6 @@ const queue = new PQueue({
 	concurrency: QUEUE_CONCURRENCY,
 	interval: QUEUE_INTERVAL,
 	intervalCap: QUEUE_INTERVAL_CAP,
-	queueClass: CustomQueueClass,
 });
 
 export const githubAppSettings: {

--- a/electron-src/utils/queue.ts
+++ b/electron-src/utils/queue.ts
@@ -1,4 +1,3 @@
 export const QUEUE_CONCURRENCY = 2; // 並列処理数
 export const QUEUE_INTERVAL = 60 * 1000; // 制約期間
-export const QUEUE_INTERVAL_CAP = 20; // 制約期間内の処理回数
-export const QUEUE_SIZE_LIMIT = 100; // キューの最大サイズ
+export const QUEUE_INTERVAL_CAP = 100; // 制約期間内の処理回数

--- a/electron-src/utils/queue.ts
+++ b/electron-src/utils/queue.ts
@@ -1,20 +1,4 @@
-import PriorityQueue, {
-	type PriorityQueueOptions,
-} from 'p-queue/dist/priority-queue';
-import { RunFunction } from 'p-queue/dist/queue';
-
 export const QUEUE_CONCURRENCY = 2; // 並列処理数
 export const QUEUE_INTERVAL = 60 * 1000; // 制約期間
 export const QUEUE_INTERVAL_CAP = 20; // 制約期間内の処理回数
 export const QUEUE_SIZE_LIMIT = 100; // キューの最大サイズ
-
-export class CustomQueueClass extends PriorityQueue {
-	enqueue(run: RunFunction, options?: Partial<PriorityQueueOptions>) {
-		if (this.size >= QUEUE_SIZE_LIMIT) {
-			if (!options || !options.priority || options.priority < 1) {
-				return;
-			}
-		}
-		super.enqueue(run, options);
-	}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react-dom": "^18.2.18",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
-        "electron": "^28.2.0",
+        "electron": "^28.2.1",
         "electron-builder": "^24.9.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3333,9 +3333,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.0.tgz",
-      "integrity": "sha512-22SylXQQ9IHtwLw4D+Z4Si7OUpeDtpHfJVTjy3yv53iLg5zJKKPOCWT4ZwgYGHQZ0eldyBrYBHF/P9FPd2CcVQ==",
+      "version": "28.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.1.tgz",
+      "integrity": "sha512-wlzXf+OvOiVlBf9dcSeMMf7Q+N6DG+wtgFbMK0sA/JpIJcdosRbLMQwLg/LTwNVKIbmayqFLDp4FmmFkEMhbYA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
-    "electron": "^28.2.0",
+    "electron": "^28.2.1",
     "electron-builder": "^24.9.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
# 概要

RateLimitのための検証中のコードと設定を見直し

# 詳細

- 検証中で不要なCustomQueueClassを削除
- リクエスト量のターゲットとして `10,000 req / 1hour` に設定
  - そこから少し余裕を持たせる形で `100 req / 1minute`
- electronを28.2.1に更新
