### PR TITLE
team mention用に取得するIssueのフィルタにsubscribedを追加

### DIFF
--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -30,7 +30,7 @@ export const githubAppSettings: {
 	readonly targetTerm: { value: number; unit: dayjs.ManipulateType };
 	readonly retentionTerm: { value: number; unit: dayjs.ManipulateType };
 } = {
-	filterTypes: ['assigned', 'created', 'mentioned'],
+	filterTypes: ['assigned', 'created', 'mentioned', 'subscribed'],
 	perPage: 100,
 	targetTerm: { value: 1, unit: 'month' },
 	retentionTerm: { value: 3, unit: 'month' },


### PR DESCRIPTION
# 概要

team mention用に取得するIssueの条件リストの中にsubscribedを追加

# 詳細

- [Mentioning people and teams](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#mentioning-people-and-teams)
- [List issues assigned to the authenticated user](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#mentioning-people-and-teams)
