### PR TITLE
本来入らないはずのコードのエラーを調整

### DIFF
--- a/renderer/components/IssueCard.tsx
+++ b/renderer/components/IssueCard.tsx
@@ -193,7 +193,7 @@ const findIssueIcon = (state: IssueState): IconDefinition => {
 			return faCodePullRequest;
 	}
 
-	safeUnreachable(state);
+	safeUnreachable('IssueState.type', state);
 };
 const findIssueStateColor = (state: IssueState) => {
 	switch (state.state) {
@@ -213,7 +213,7 @@ const findIssueStateColor = (state: IssueState) => {
 			return githubColor.draft;
 	}
 
-	safeUnreachable(state);
+	safeUnreachable('IssueState.state', state);
 };
 const findIssueReviewStateIcon = (state: Review['state']) => {
 	switch (state) {
@@ -227,5 +227,5 @@ const findIssueReviewStateIcon = (state: Review['state']) => {
 			return 'default';
 	}
 
-	safeUnreachable(state);
+	safeUnreachable('Review.state', state);
 };

--- a/renderer/context/IssueFilterContext.ts
+++ b/renderer/context/IssueFilterContext.ts
@@ -83,7 +83,7 @@ export const fromFilterType = (type: IssueFilterTypes): IssueFilter => {
 			return issueFilterMyPr;
 	}
 
-	safeUnreachable(type);
+	safeUnreachable('IssueFilterTypes', type);
 };
 
 const checkOwnIssue = (issue: Issue, user: UserInfo | null) => {

--- a/renderer/utils/typescript.ts
+++ b/renderer/utils/typescript.ts
@@ -1,3 +1,3 @@
-export const safeUnreachable = (_x: never): never => {
-	throw new Error('Unreachable code');
+export const safeUnreachable = (type: string, x: never): never => {
+	throw new Error(`Unreachable code ${type}: ${JSON.stringify(x)}`);
 };


### PR DESCRIPTION
# 概要

switch文で本来入らないcaseのときのエラー文言を詳細化

# 詳細

- 渡ってきたデータをエラーログに出力
- それがどういうデータなのかも出力
