### PR TITLE
PRレビューのDISMISSEDに対応

### DIFF
--- a/electron-src/types/GitHub.d.ts
+++ b/electron-src/types/GitHub.d.ts
@@ -77,7 +77,12 @@ export interface GithubPrReview {
 	id: number;
 	node_id: string;
 	user: GithubUserMinimumInfo;
-	state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'PENDING';
+	state:
+		| 'APPROVED'
+		| 'CHANGES_REQUESTED'
+		| 'COMMENTED'
+		| 'PENDING'
+		| 'DISMISSED';
 }
 
 type GithubFullIssueData = {

--- a/renderer/components/IssueCard.tsx
+++ b/renderer/components/IssueCard.tsx
@@ -224,6 +224,7 @@ const findIssueReviewStateIcon = (state: Review['state']) => {
 		case 'COMMENTED':
 			return 'ordinarily';
 		case 'PENDING':
+		case 'DISMISSED':
 			return 'default';
 	}
 

--- a/types/Issue.d.ts
+++ b/types/Issue.d.ts
@@ -35,7 +35,12 @@ export interface UserInfo {
 export interface Review {
 	login: string;
 	avatarUrl: string;
-	state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'PENDING';
+	state:
+		| 'APPROVED'
+		| 'CHANGES_REQUESTED'
+		| 'COMMENTED'
+		| 'PENDING'
+		| 'DISMISSED';
 }
 
 export interface IssueSupplementMapData {


### PR DESCRIPTION
# 概要

PRレビューのstateがdismissedのときでも許容できるようにする

# 詳細

- PRレビューのstateがdismissedを想定する
- dismissedのときはsubmit前と同様にbadge無しで表示する
