### PR TITLE
ダークモードの設定をアプリ再起動時にも引き継ぐ

### DIFF
--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -57,10 +57,15 @@ const setupMainWindow = () => {
 	const mainWindow = windowUtils.createMain();
 	let isFirst = true;
 	ipcMain.handle('app:version', () => `v${app.getVersion()}`);
+	ipcMain.handle('app:color', () => store.get('color'));
 	ipcMain.on('app:ready', (_event) => {
 		log.verbose('App renderer is ready');
 		sendMainData(mainWindow, isFirst);
 		isFirst = false;
+	});
+	ipcMain.on('app:setColor', (_event, mode: 'light' | 'dark') => {
+		log.verbose('App ColorMode is changed', mode);
+		store.set('color', mode);
 	});
 
 	return mainWindow;

--- a/electron-src/main.ts
+++ b/electron-src/main.ts
@@ -57,7 +57,7 @@ const setupMainWindow = () => {
 	const mainWindow = windowUtils.createMain();
 	let isFirst = true;
 	ipcMain.handle('app:version', () => `v${app.getVersion()}`);
-	ipcMain.handle('app:color', () => store.get('color'));
+	ipcMain.handle('app:color', () => store.get('color', 'light'));
 	ipcMain.on('app:ready', (_event) => {
 		log.verbose('App renderer is ready');
 		sendMainData(mainWindow, isFirst);

--- a/electron-src/preload/about.ts
+++ b/electron-src/preload/about.ts
@@ -3,6 +3,7 @@ import type { ErrorData } from '../../types/Error';
 
 contextBridge.exposeInMainWorld('about', {
 	version: () => ipcRenderer.invoke('app:version'),
+	color: () => ipcRenderer.invoke('app:color'),
 	close: () => ipcRenderer.send('about:close'),
 	open: (url: string) => ipcRenderer.send('browser:open', url),
 });

--- a/electron-src/preload/main.ts
+++ b/electron-src/preload/main.ts
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('electron', {
 	) => ipcRenderer.on('browser:load', (_event, value) => callback(value)),
 
 	ready: () => ipcRenderer.send('app:ready'),
+	color: () => ipcRenderer.invoke('app:color'),
 	pushUser: (callback: (user: UserInfo) => void) =>
 		ipcRenderer.on('app:pushUser', (_event, value) => callback(value)),
 	pushIssues: (callback: (issues: Issue[]) => void) =>
@@ -31,6 +32,7 @@ contextBridge.exposeInMainWorld('electron', {
 		ipcRenderer.on('app:pushIssueSupplementMap', (_event, value) =>
 			callback(value),
 		),
+	setColor: (mode: 'light' | 'dark') => ipcRenderer.send('app:setColor', mode),
 });
 
 contextBridge.exposeInMainWorld('error', {

--- a/electron-src/preload/setting.ts
+++ b/electron-src/preload/setting.ts
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld('setting', {
 	display: () => ipcRenderer.invoke('setting:display'),
 	submit: (data: SettingData) => ipcRenderer.send('setting:submit', data),
 	cancel: () => ipcRenderer.send('setting:cancel'),
+	color: () => ipcRenderer.invoke('app:color'),
 });
 
 contextBridge.exposeInMainWorld('error', {

--- a/electron-src/preload/update.ts
+++ b/electron-src/preload/update.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('update', {
 	download: () => ipcRenderer.send('update:download'),
 	copy: (command: string) => ipcRenderer.send('update:copy', command),
 	openRelease: () => ipcRenderer.send('update:openRelease'),
+	color: () => ipcRenderer.invoke('app:color'),
 	openLink: (url: string) => ipcRenderer.send('browser:open', url),
 	close: () => ipcRenderer.send('update:close'),
 });

--- a/electron-src/preload/update.ts
+++ b/electron-src/preload/update.ts
@@ -8,9 +8,9 @@ contextBridge.exposeInMainWorld('update', {
 	download: () => ipcRenderer.send('update:download'),
 	copy: (command: string) => ipcRenderer.send('update:copy', command),
 	openRelease: () => ipcRenderer.send('update:openRelease'),
-	color: () => ipcRenderer.invoke('app:color'),
 	openLink: (url: string) => ipcRenderer.send('browser:open', url),
 	close: () => ipcRenderer.send('update:close'),
+	color: () => ipcRenderer.invoke('app:color'),
 });
 
 contextBridge.exposeInMainWorld('error', {

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -13,6 +13,7 @@ export const store = new Store<{
 		issues: Issue[];
 	};
 	issueSupplementMap: IssueSupplementMap;
+	colorMode: 'light' | 'dark';
 }>({
 	schema: {
 		appVersion: {
@@ -149,6 +150,11 @@ export const store = new Store<{
 					},
 				},
 			},
+		},
+		colorMode: {
+			type: 'string',
+			enum: ['light', 'dark'],
+			default: 'light',
 		},
 	},
 });

--- a/renderer/components/Menu.tsx
+++ b/renderer/components/Menu.tsx
@@ -181,7 +181,9 @@ const UpdatedAt = () => {
 					aria-label="toggle color mode"
 					size="small"
 					onClick={() => {
-						colorModeDispatch(colorMode === 'light' ? 'dark' : 'light');
+						const mode = colorMode === 'light' ? 'dark' : 'light';
+						colorModeDispatch(mode);
+						window.electron.setColor(mode);
 					}}
 				>
 					<FontAwesomeIcon icon={colorMode === 'light' ? faSun : faMoon} />

--- a/renderer/components/Menu.tsx
+++ b/renderer/components/Menu.tsx
@@ -158,6 +158,7 @@ const UpdatedAt = () => {
 			if (!updatedAt) return '';
 			setUpdatedAt(dayjs(updatedAt).format('YYYY/MM/DD HH:mm:ss'));
 		});
+		window.electron.color().then(colorModeDispatch);
 	}, []);
 
 	return (

--- a/renderer/interfaces/index.ts
+++ b/renderer/interfaces/index.ts
@@ -1,3 +1,4 @@
+import type { PaletteMode } from '@mui/material';
 import type { UserInfo } from '../../types/User';
 import type { Issue, IssueSupplementMap } from '../../types/Issue';
 import type { UpdateStatus } from '../../types/Update';
@@ -22,23 +23,24 @@ declare global {
 				}) => void,
 			) => void;
 			ready: () => void;
-			color: () => Promise<'light' | 'dark'>;
+			color: () => Promise<PaletteMode>;
 			pushUser: (callback: (user: UserInfo) => void) => void;
 			pushIssues: (callback: (issues: Issue[]) => void) => void;
 			pushUpdatedAt: (callback: (updatedAt: string) => void) => void;
 			pushIssueSupplementMap: (
 				callback: (map: IssueSupplementMap) => void,
 			) => void;
+			setColor: (mode: PaletteMode) => void;
 		};
 		setting: {
 			display: () => Promise<SettingData>;
 			submit: (data: SettingData) => void;
 			cancel: () => void;
-			color: () => Promise<'light' | 'dark'>;
+			color: () => Promise<PaletteMode>;
 		};
 		about: {
 			version: () => Promise<string>;
-			color: () => Promise<'light' | 'dark'>;
+			color: () => Promise<PaletteMode>;
 			close: () => void;
 			open: (url: string) => void;
 		};
@@ -49,7 +51,7 @@ declare global {
 			openRelease: () => void;
 			openLink: (url: string) => void;
 			close: () => void;
-			color: () => Promise<'light' | 'dark'>;
+			color: () => Promise<PaletteMode>;
 		};
 		error: {
 			throw: (error: ErrorData) => void;

--- a/renderer/interfaces/index.ts
+++ b/renderer/interfaces/index.ts
@@ -22,6 +22,7 @@ declare global {
 				}) => void,
 			) => void;
 			ready: () => void;
+			color: () => Promise<'light' | 'dark'>;
 			pushUser: (callback: (user: UserInfo) => void) => void;
 			pushIssues: (callback: (issues: Issue[]) => void) => void;
 			pushUpdatedAt: (callback: (updatedAt: string) => void) => void;
@@ -33,9 +34,11 @@ declare global {
 			display: () => Promise<SettingData>;
 			submit: (data: SettingData) => void;
 			cancel: () => void;
+			color: () => Promise<'light' | 'dark'>;
 		};
 		about: {
 			version: () => Promise<string>;
+			color: () => Promise<'light' | 'dark'>;
 			close: () => void;
 			open: (url: string) => void;
 		};
@@ -46,6 +49,7 @@ declare global {
 			openRelease: () => void;
 			openLink: (url: string) => void;
 			close: () => void;
+			color: () => Promise<'light' | 'dark'>;
 		};
 		error: {
 			throw: (error: ErrorData) => void;


### PR DESCRIPTION
# 概要

ダークモードの設定を保存して、アプリを再起動した際にも引き継がれるようにする。

# 詳細

- カラーモードの設定をローカルストレージに保存する
- アプリの起動時にローカルストレージに保存されている状態を反映する

# 期待値

- [x] 閉じる前の設定が反映されている
