### PR TITLE
全てを既読にするときの書き込み量を減らす

### DIFF
--- a/electron-src/models/ContextMenu.ts
+++ b/electron-src/models/ContextMenu.ts
@@ -16,8 +16,12 @@ export const createFilterMenu = (type: IssueFilterTypes) => {
 					issues: [],
 				});
 				const user = store.get('userInfo');
+				const readIssues = Object.entries(store.get('issueSupplementMap', {}))
+					.filter(([_key, value]) => value.isRead)
+					.map(([key, _value]) => key);
 				issues
 					.filter((issue) => choiceIssueFilterFunction(type)(issue, { user }))
+					.filter((issue) => !readIssues.includes(issue.key))
 					.forEach((issue) => {
 						store.set(`issueSupplementMap.${issue.key}.isRead`, true);
 					});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
-        "electron": "^30.0.2",
+        "electron": "^30.1.0",
         "electron-builder": "^24.13.3",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3495,11 +3495,12 @@
       }
     },
     "node_modules/electron": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.2.tgz",
-      "integrity": "sha512-zv7T+GG89J/hyWVkQsLH4Y/rVEfqJG5M/wOBIGNaDdqd8UV9/YZPdS7CuFeaIj0H9LhCt95xkIQNpYB/3svOkQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.1.0.tgz",
+      "integrity": "sha512-9O8m7kinjwMH5Df0hpXbwUaqI6pk3aJm1sKQUkQGCF7NDbNkGhu2BXgqaicPU6oe26zQPc5vtwWnHmiKlh1hYA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
-    "electron": "^30.0.2",
+    "electron": "^30.1.0",
     "electron-builder": "^24.13.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
# 概要

「全て既読にする」からデータを書き込む対象を減らしてファイルアクセス量を減らす。

# 詳細

- Electronをv30.1.0に上げる
  - https://releases.electronjs.org/release/v30.1.0
- 「全て既読にする」からデータを書き込む対象を減らす
