### PR TITLE
Enterprise版などで画像などへのアクセスにCookieが必要な場合のための対応

### DIFF
--- a/docs/detail/setup.md
+++ b/docs/detail/setup.md
@@ -12,17 +12,15 @@ Amethystを使用するためには、以下2つの設定が必要です。
 
 ## URL
 
-URLには以下を設定してください。
+URLには以下のようにGitHubのトップページURLを設定してください。
 
 ```
-https://api.github.com/
+https://github.com/
 ```
 
-GitHub EnterpriseでURLが変わる場合は以下のように設定してください。
+GitHub EnterpriseでURLが変わる場合でも同様にトップページURLを設定してください。
 
-```
-https://(Domain)/api/v3/
-```
+例: `https://enterprise.github.xyz/`
 
 ## Token
 

--- a/electron-src/constant/GithubConstant.ts
+++ b/electron-src/constant/GithubConstant.ts
@@ -1,0 +1,7 @@
+export const URL = 'https://github.com/';
+export const API_URL = 'https://api.github.com/';
+
+export default {
+	URL,
+	API_URL,
+} as const;

--- a/electron-src/models/AppMenu.ts
+++ b/electron-src/models/AppMenu.ts
@@ -20,7 +20,7 @@ import { announceUpdate } from '../utils/release';
 import { store } from '../utils/store';
 import { isMac } from '../utils/window';
 import GithubConstant from '../constant/GithubConstant';
-import type { SettingData } from '../preload/setting';
+import type { SettingData } from '../../types/Setting';
 
 export const createMenu = ({
 	mainWindow,
@@ -81,7 +81,7 @@ export const createMenu = ({
 					token:
 						data.token &&
 						safeStorage.encryptString(data.token).toString('base64'),
-					url: data.baseUrl,
+					url: data.url,
 				});
 				settingWindow.hide();
 

--- a/electron-src/models/AppMenu.ts
+++ b/electron-src/models/AppMenu.ts
@@ -67,11 +67,12 @@ export const createMenu = ({
 		.on(
 			'setting:submit',
 			(_event: Electron.IpcMainEvent, data: SettingData) => {
+				const url = new URL(data.url);
 				store.set('githubSetting', {
 					token:
 						data.token &&
 						safeStorage.encryptString(data.token).toString('base64'),
-					url: data.url,
+					url: url.href,
 				});
 				settingWindow.hide();
 

--- a/electron-src/models/AppMenu.ts
+++ b/electron-src/models/AppMenu.ts
@@ -19,6 +19,7 @@ import {
 import { announceUpdate } from '../utils/release';
 import { store } from '../utils/store';
 import { isMac } from '../utils/window';
+import GithubConstant from '../constant/GithubConstant';
 import type { SettingData } from '../preload/setting';
 
 export const createMenu = ({
@@ -65,8 +66,9 @@ export const createMenu = ({
 	ipcMain.handle('setting:display', async () => {
 		return {
 			baseUrl: store.get('githubSetting', {
-				baseUrl: 'https://api.github.com/',
+				baseUrl: GithubConstant.API_URL,
 				token: '',
+				url: GithubConstant.URL,
 			}).baseUrl,
 		};
 	});
@@ -79,6 +81,7 @@ export const createMenu = ({
 					token:
 						data.token &&
 						safeStorage.encryptString(data.token).toString('base64'),
+					url: data.baseUrl,
 				});
 				settingWindow.hide();
 

--- a/electron-src/models/AppMenu.ts
+++ b/electron-src/models/AppMenu.ts
@@ -19,7 +19,6 @@ import {
 import { announceUpdate } from '../utils/release';
 import { store } from '../utils/store';
 import { isMac } from '../utils/window';
-import GithubConstant from '../constant/GithubConstant';
 import type { SettingData } from '../../types/Setting';
 
 export const createMenu = ({
@@ -63,21 +62,12 @@ export const createMenu = ({
 		},
 	]);
 
-	ipcMain.handle('setting:display', async () => {
-		return {
-			baseUrl: store.get('githubSetting', {
-				baseUrl: GithubConstant.API_URL,
-				token: '',
-				url: GithubConstant.URL,
-			}).baseUrl,
-		};
-	});
+	ipcMain.handle('setting:display', () => store.get('githubSetting'));
 	ipcMain
 		.on(
 			'setting:submit',
 			(_event: Electron.IpcMainEvent, data: SettingData) => {
 				store.set('githubSetting', {
-					baseUrl: data.baseUrl,
 					token:
 						data.token &&
 						safeStorage.encryptString(data.token).toString('base64'),

--- a/electron-src/preload/setting.ts
+++ b/electron-src/preload/setting.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import type { ErrorData } from '../../types/Error';
+import type { SettingData } from '../../types/Setting';
 
 contextBridge.exposeInMainWorld('setting', {
 	display: () => ipcRenderer.invoke('setting:display'),
@@ -12,5 +13,3 @@ contextBridge.exposeInMainWorld('error', {
 	throw: (error: ErrorData) => ipcRenderer.send('error:throw', error),
 	getPath: () => ipcRenderer.invoke('error:path'),
 });
-
-export type SettingData = { baseUrl: string; token?: string };

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -8,6 +8,7 @@ import {
 } from '../tanslators/GithubTranslator';
 import { QUEUE_CONCURRENCY, QUEUE_INTERVAL, QUEUE_INTERVAL_CAP } from './queue';
 import { store } from './store';
+import GithubConstant from '../constant/GithubConstant';
 import StoreDataFlag from '../enum/StoreDataFlag';
 import type {
 	GithubUserInfo,
@@ -86,7 +87,7 @@ export const gainPrReviews = async (repository: string, prNumber: number) => {
 
 export const checkStoreData = () => {
 	const githubSetting = store.get('githubSetting');
-	return githubSetting?.baseUrl && githubSetting?.token
+	return githubSetting && githubSetting.url && githubSetting.token
 		? StoreDataFlag.VALID
 		: StoreDataFlag.INVALID;
 };
@@ -263,16 +264,24 @@ const getBaseUrl = () => {
 	const baseUrl = store.get('githubSetting', {
 		baseUrl: '',
 		token: '',
-	}).baseUrl;
+		url: '',
+	}).url;
 	if (!baseUrl) {
-		throw new Error('No GitHub baseURL set. Please set one in the settings.');
+		throw new Error('No GitHub url set. Please set one in the settings.');
 	}
 
-	return baseUrl;
+	if (baseUrl === GithubConstant.URL) {
+		return GithubConstant.API_URL;
+	}
+	return `${baseUrl}api/v3/`;
 };
 
 const getToken = () => {
-	const token = store.get('githubSetting', { baseUrl: '', token: '' }).token;
+	const token = store.get('githubSetting', {
+		baseUrl: '',
+		token: '',
+		url: '',
+	}).token;
 	if (!token) {
 		throw new Error('No GitHub token set. Please set one in the settings.');
 	}

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -262,7 +262,6 @@ const requestToGithub = async (url: URL) => {
 
 const getBaseUrl = () => {
 	const baseUrl = store.get('githubSetting', {
-		baseUrl: '',
 		token: '',
 		url: '',
 	}).url;
@@ -278,7 +277,6 @@ const getBaseUrl = () => {
 
 const getToken = () => {
 	const token = store.get('githubSetting', {
-		baseUrl: '',
 		token: '',
 		url: '',
 	}).token;

--- a/electron-src/utils/github.ts
+++ b/electron-src/utils/github.ts
@@ -261,18 +261,18 @@ const requestToGithub = async (url: URL) => {
 };
 
 const getBaseUrl = () => {
-	const baseUrl = store.get('githubSetting', {
+	const url = store.get('githubSetting', {
 		token: '',
 		url: '',
 	}).url;
-	if (!baseUrl) {
+	if (!url) {
 		throw new Error('No GitHub url set. Please set one in the settings.');
 	}
 
-	if (baseUrl === GithubConstant.URL) {
+	if (url === GithubConstant.URL) {
 		return GithubConstant.API_URL;
 	}
-	return `${baseUrl}api/v3/`;
+	return new URL('api/v3', url).href;
 };
 
 const getToken = () => {

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -1,12 +1,13 @@
 import { app } from 'electron';
 import Store from 'electron-store';
 import semver from 'semver';
+import GithubConstant from '../constant/GithubConstant';
 import type { UserInfo } from '../../types/User';
 import type { Issue, IssueSupplementMap } from '../../types/Issue';
 
 export const store = new Store<{
 	appVersion: string;
-	githubSetting: { baseUrl: string; token: string };
+	githubSetting: { baseUrl: string; token: string; url: string };
 	userInfo: UserInfo;
 	issueData: {
 		updatedAt: string;
@@ -27,6 +28,10 @@ export const store = new Store<{
 				},
 				token: {
 					type: 'string',
+				},
+				url: {
+					type: 'string',
+					default: GithubConstant.URL,
 				},
 			},
 		},

--- a/electron-src/utils/store.ts
+++ b/electron-src/utils/store.ts
@@ -4,10 +4,11 @@ import semver from 'semver';
 import GithubConstant from '../constant/GithubConstant';
 import type { UserInfo } from '../../types/User';
 import type { Issue, IssueSupplementMap } from '../../types/Issue';
+import type { SettingData } from '../../types/Setting';
 
 export const store = new Store<{
 	appVersion: string;
-	githubSetting: { baseUrl: string; token: string; url: string };
+	githubSetting: SettingData;
 	userInfo: UserInfo;
 	issueData: {
 		updatedAt: string;
@@ -23,9 +24,6 @@ export const store = new Store<{
 		githubSetting: {
 			type: 'object',
 			properties: {
-				baseUrl: {
-					type: 'string',
-				},
 				token: {
 					type: 'string',
 				},

--- a/renderer/interfaces/index.ts
+++ b/renderer/interfaces/index.ts
@@ -1,9 +1,10 @@
 import type { PaletteMode } from '@mui/material';
-import type { UserInfo } from '../../types/User';
-import type { Issue, IssueSupplementMap } from '../../types/Issue';
-import type { UpdateStatus } from '../../types/Update';
 import type { ErrorData } from '../../types/Error';
+import type { Issue, IssueSupplementMap } from '../../types/Issue';
 import type { IssueFilterTypes } from '../../types/IssueFilter';
+import type { SettingData } from '../../types/Setting';
+import type { UpdateStatus } from '../../types/Update';
+import type { UserInfo } from '../../types/User';
 
 declare global {
 	interface Window {
@@ -63,5 +64,3 @@ declare global {
 		};
 	}
 }
-
-export type SettingData = { baseUrl: string; token?: string };

--- a/renderer/pages/setting.tsx
+++ b/renderer/pages/setting.tsx
@@ -13,10 +13,10 @@ import {
 	Typography,
 } from '@mui/material';
 import { Heading } from '../components/Heading';
-import type { SettingData } from '../interfaces';
+import type { SettingData } from '../../types/Setting';
 
 const SettingPage = () => {
-	const [data, setData] = useState<SettingData>({ baseUrl: '' });
+	const [data, setData] = useState<SettingData>({ baseUrl: '', url: '' });
 	useEffect(() => {
 		window.setting
 			?.display()
@@ -29,7 +29,11 @@ const SettingPage = () => {
 	}, []);
 
 	const handleSubmit = () => {
-		window.setting?.submit({ baseUrl: data.baseUrl, token: data.token });
+		window.setting?.submit({
+			baseUrl: data.baseUrl,
+			token: data.token,
+			url: data.url,
+		});
 	};
 	const handleCancel = () => {
 		window.setting?.cancel();
@@ -55,9 +59,9 @@ const SettingPage = () => {
 								</TableCell>
 								<TableCell>
 									<TextField
-										value={data.baseUrl}
+										value={data.url}
 										onChange={(e) =>
-											setData(() => ({ ...data, baseUrl: e.target.value }))
+											setData(() => ({ ...data, url: e.target.value }))
 										}
 										variant="standard"
 									/>

--- a/renderer/pages/setting.tsx
+++ b/renderer/pages/setting.tsx
@@ -16,7 +16,7 @@ import { Heading } from '../components/Heading';
 import type { SettingData } from '../../types/Setting';
 
 const SettingPage = () => {
-	const [data, setData] = useState<SettingData>({ baseUrl: '', url: '' });
+	const [data, setData] = useState<SettingData>({ url: '' });
 	useEffect(() => {
 		window.setting
 			?.display()
@@ -30,7 +30,6 @@ const SettingPage = () => {
 
 	const handleSubmit = () => {
 		window.setting?.submit({
-			baseUrl: data.baseUrl,
 			token: data.token,
 			url: data.url,
 		});

--- a/types/Setting.d.ts
+++ b/types/Setting.d.ts
@@ -1,0 +1,1 @@
+export type SettingData = { baseUrl: string; token?: string; url: string };

--- a/types/Setting.d.ts
+++ b/types/Setting.d.ts
@@ -1,1 +1,1 @@
-export type SettingData = { baseUrl: string; token?: string; url: string };
+export type SettingData = { url: string; token?: string };


### PR DESCRIPTION
# 概要

Enterprise版でAPIだけでなく、Amethystに表示するコンテンツにログインCookieが必要なケースがあります。
それに対応するために、Webviewで設定されたログインCookieをAmethyst全体に伝播するようにしました。

# 詳細

- Webviewで設定されたGitHubへのログインCookieをAmethyst全体に設定する
- Cookieのfilter用にURLの設定をAPI EndpointからサーバURLに変更

# 期待値

- [ ] URLの変更後にIssueなどが取得できる
- [ ] Amethyst全体で画像などが取得・表示できる
